### PR TITLE
[codex] fix unit test setup

### DIFF
--- a/src/graph_sitter/compiled/autocommit.pyx
+++ b/src/graph_sitter/compiled/autocommit.pyx
@@ -1,6 +1,6 @@
 import functools
 from collections.abc import Callable
-from typing import Any, ParamSpec, TypeVar, Union, overload
+from typing import Any, ParamSpec, TypeVar, Union
 
 import wrapt
 
@@ -18,14 +18,6 @@ def is_outdated(c) -> bool:
     if isinstance(c, list):
         return any(is_outdated(i) for i in c)
     return False
-
-
-@overload
-def reader(wrapped: Callable[P, T]) -> Callable[P, T]: ...
-
-
-@overload
-def reader(wrapped: None = None, *, cache: bool | None = ...) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
 def reader(wrapped: Callable[P, T] | None = None, *, cache: bool | None = None) -> Callable[P, T] | Callable[[Callable[P, T]], Callable[P, T]]:
@@ -174,14 +166,6 @@ def update_dict(seen: set["Editable"], obj: "Editable", new_obj: "Editable"):
     assert new_obj.ts_node == obj.ts_node
     assert new_obj.is_same_version(obj)
     assert not obj.is_outdated
-
-
-@overload
-def commiter(wrapped: Callable[P, T]) -> Callable[P, T]: ...
-
-
-@overload
-def commiter(wrapped: None = None, *, reset: bool = ...) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
 def commiter(wrapped: Callable[P, T] | None = None, *, reset: bool = False) -> Callable[P, T] | Callable[[Callable[P, T]], Callable[P, T]]:

--- a/src/graph_sitter/git/repo_operator/repo_operator.py
+++ b/src/graph_sitter/git/repo_operator/repo_operator.py
@@ -488,7 +488,7 @@ class RepoOperator:
 
     def commit_changes(self, message: str, verify: bool = False) -> bool:
         """Returns True if a commit was made and False otherwise."""
-        staged_changes = self.git_cli.git.diff("--staged")
+        staged_changes = self.git_cli.git.diff("--no-ext-diff", "--staged")
         if staged_changes:
             if self.bot_commit and (info := self._get_username_email()):
                 user, email = info


### PR DESCRIPTION
## Summary
- keep Cython overload declarations out of the compiled runtime source
- ignore external Git diff drivers when checking staged changes before commits

## Why
The dependency install and unit test setup initially hit two local-environment-sensitive blockers: Cython import initialization failed on runtime overload stubs, and a global external diff driver failed on intentionally binary/non-UTF-8 test fixtures.

## Validation
- uv sync --dev --reinstall-package graph-sitter
- uv run pytest tests/unit -n auto

Final unit result: 2116 passed, 58 skipped, 12 xfailed.