### PR TITLE
Add interactive Next.js dependency-graph explorer (/explore)

### DIFF
--- a/site/app/explore/page.tsx
+++ b/site/app/explore/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { Wordmark } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
 import {
-  DependencyGraph,
-  type DepGraphData
+	type DepGraphData,
+	DependencyGraph,
 } from "@/components/visualizations/dependency-graph";
 import depGraph from "@/lib/data/nextjs-depgraph.json";
 
@@ -14,130 +14,130 @@ const data = depGraph as DepGraphData;
 const githubUrl = "https://github.com/codegen-sh/graph-sitter";
 
 export const metadata: Metadata = {
-  title: "The shape of Next.js | Graph-sitter",
-  description:
-    "An interactive dependency graph of the Next.js framework core, parsed with graph-sitter."
+	title: "The shape of Next.js | Graph-sitter",
+	description:
+		"An interactive dependency graph of the Next.js framework core, parsed with graph-sitter.",
 };
 
 const hubs = [...data.nodes].sort((a, b) => b.inbound - a.inbound).slice(0, 6);
 
 export default function ExplorePage() {
-  return (
-    <div className="flex min-h-screen flex-col">
-      <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-xl">
-        <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-6 lg:px-8">
-          <Link href="/" aria-label="Graph-sitter home">
-            <Wordmark />
-          </Link>
-          <nav className="flex items-center gap-1">
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <Link href="/docs">Docs</Link>
-            </Button>
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
-            >
-              <a href={githubUrl} target="_blank" rel="noreferrer">
-                GitHub
-              </a>
-            </Button>
-            <ThemeToggle />
-          </nav>
-        </div>
-      </header>
+	return (
+		<div className="flex min-h-screen flex-col">
+			<header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-xl">
+				<div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-6 lg:px-8">
+					<Link href="/" aria-label="Graph-sitter home">
+						<Wordmark />
+					</Link>
+					<nav className="flex items-center gap-1">
+						<Button
+							asChild
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground hover:text-foreground"
+						>
+							<Link href="/docs">Docs</Link>
+						</Button>
+						<Button
+							asChild
+							variant="ghost"
+							size="sm"
+							className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
+						>
+							<a href={githubUrl} target="_blank" rel="noreferrer">
+								GitHub
+							</a>
+						</Button>
+						<ThemeToggle />
+					</nav>
+				</div>
+			</header>
 
-      <main className="mx-auto w-full max-w-6xl flex-1 px-6 py-12 lg:px-8 lg:py-16">
-        <div className="max-w-2xl">
-          <h1 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
-            The shape of Next.js
-          </h1>
-          <p className="mt-3 text-base leading-relaxed text-muted-foreground sm:text-lg">
-            Every module in the Next.js framework core, wired by its real import
-            graph. Graph-sitter parsed{" "}
-            <code className="rounded-md border border-border bg-muted/60 px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">
-              packages/next/src
-            </code>{" "}
-            — {data.meta.files.toLocaleString()} files,{" "}
-            {data.meta.symbols.toLocaleString()} symbols — in{" "}
-            {data.meta.parse_seconds}s.
-          </p>
-        </div>
+			<main className="mx-auto w-full max-w-6xl flex-1 px-6 py-12 lg:px-8 lg:py-16">
+				<div className="max-w-2xl">
+					<h1 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+						The shape of Next.js
+					</h1>
+					<p className="mt-3 text-base leading-relaxed text-muted-foreground sm:text-lg">
+						Every module in the Next.js framework core, wired by its real import
+						graph. Graph-sitter parsed{" "}
+						<code className="rounded-md border border-border bg-muted/60 px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">
+							packages/next/src
+						</code>{" "}
+						— {data.meta.files.toLocaleString()} files,{" "}
+						{data.meta.symbols.toLocaleString()} symbols — in{" "}
+						{data.meta.parse_seconds}s.
+					</p>
+				</div>
 
-        <div className="mt-8">
-          <DependencyGraph data={data} />
-        </div>
+				<div className="mt-8">
+					<DependencyGraph data={data} />
+				</div>
 
-        <section className="mt-10 grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
-          <div>
-            <h2 className="text-lg font-semibold tracking-tight">
-              Most-depended-on modules
-            </h2>
-            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-              Ranked by inbound imports — the modules that the rest of the
-              framework leans on hardest.
-            </p>
-            <ul className="mt-4 overflow-hidden rounded-xl border border-border">
-              {hubs.map((n, i) => (
-                <li
-                  key={n.id}
-                  className="flex items-center gap-3 border-b border-border bg-card px-4 py-2.5 text-sm last:border-b-0"
-                >
-                  <span className="w-4 text-right font-mono text-xs text-muted-foreground">
-                    {i + 1}
-                  </span>
-                  <span className="font-mono text-foreground">{n.id}</span>
-                  <span className="ml-auto font-medium text-foreground">
-                    {n.inbound}
-                  </span>
-                  <span className="text-xs text-muted-foreground">imports</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+				<section className="mt-10 grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+					<div>
+						<h2 className="text-lg font-semibold tracking-tight">
+							Most-depended-on modules
+						</h2>
+						<p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+							Ranked by inbound imports — the modules that the rest of the
+							framework leans on hardest.
+						</p>
+						<ul className="mt-4 overflow-hidden rounded-xl border border-border">
+							{hubs.map((n, i) => (
+								<li
+									key={n.id}
+									className="flex items-center gap-3 border-b border-border bg-card px-4 py-2.5 text-sm last:border-b-0"
+								>
+									<span className="w-4 text-right font-mono text-xs text-muted-foreground">
+										{i + 1}
+									</span>
+									<span className="font-mono text-foreground">{n.id}</span>
+									<span className="ml-auto font-medium text-foreground">
+										{n.inbound}
+									</span>
+									<span className="text-xs text-muted-foreground">imports</span>
+								</li>
+							))}
+						</ul>
+					</div>
 
-          <div>
-            <h2 className="text-lg font-semibold tracking-tight">
-              How this was built
-            </h2>
-            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-              No language server, no IDE — just the graph-sitter Rust backend
-              resolving imports across the whole tree.
-            </p>
-            <pre className="code-surface mt-4 overflow-x-auto px-4 py-3.5 font-mono text-[0.8rem] leading-relaxed">
-              <code>
-                <span className="block">
-                  <span className="text-aura-green">uvx</span> graph-sitter parse
-                  packages/next/src \
-                </span>
-                <span className="block pl-[2ch] text-muted-foreground">
-                  --backend rust --format json
-                </span>
-              </code>
-            </pre>
-            <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-              The resulting graph — {data.meta.modules} modules and{" "}
-              {data.meta.edges} aggregated import edges — is laid out live in
-              your browser with a force simulation.
-            </p>
-          </div>
-        </section>
-      </main>
+					<div>
+						<h2 className="text-lg font-semibold tracking-tight">
+							How this was built
+						</h2>
+						<p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+							No language server, no IDE — just the graph-sitter Rust backend
+							resolving imports across the whole tree.
+						</p>
+						<pre className="code-surface mt-4 overflow-x-auto px-4 py-3.5 font-mono text-[0.8rem] leading-relaxed">
+							<code>
+								<span className="block">
+									<span className="text-aura-green">uvx</span> graph-sitter
+									parse packages/next/src \
+								</span>
+								<span className="block pl-[2ch] text-muted-foreground">
+									--backend rust --format json
+								</span>
+							</code>
+						</pre>
+						<p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+							The resulting graph — {data.meta.modules} modules and{" "}
+							{data.meta.edges} aggregated import edges — is laid out live in
+							your browser with a force simulation.
+						</p>
+					</div>
+				</section>
+			</main>
 
-      <footer className="border-t border-border/60">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-8 text-sm text-muted-foreground lg:px-8">
-          <span>Codebase graphs for codemods.</span>
-          <Link href="/docs" className="hover:text-foreground">
-            Read the docs
-          </Link>
-        </div>
-      </footer>
-    </div>
-  );
+			<footer className="border-t border-border/60">
+				<div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-8 text-sm text-muted-foreground lg:px-8">
+					<span>Codebase graphs for codemods.</span>
+					<Link href="/docs" className="hover:text-foreground">
+						Read the docs
+					</Link>
+				</div>
+			</footer>
+		</div>
+	);
 }

--- a/site/app/explore/page.tsx
+++ b/site/app/explore/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Wordmark } from "@/components/logo";
+import { ThemeToggle } from "@/components/theme-toggle";
+import {
+  DependencyGraph,
+  type DepGraphData
+} from "@/components/visualizations/dependency-graph";
+import depGraph from "@/lib/data/nextjs-depgraph.json";
+
+const data = depGraph as DepGraphData;
+const githubUrl = "https://github.com/codegen-sh/graph-sitter";
+
+export const metadata: Metadata = {
+  title: "The shape of Next.js | Graph-sitter",
+  description:
+    "An interactive dependency graph of the Next.js framework core, parsed with graph-sitter."
+};
+
+const hubs = [...data.nodes].sort((a, b) => b.inbound - a.inbound).slice(0, 6);
+
+export default function ExplorePage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-xl">
+        <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-6 lg:px-8">
+          <Link href="/" aria-label="Graph-sitter home">
+            <Wordmark />
+          </Link>
+          <nav className="flex items-center gap-1">
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Link href="/docs">Docs</Link>
+            </Button>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
+            >
+              <a href={githubUrl} target="_blank" rel="noreferrer">
+                GitHub
+              </a>
+            </Button>
+            <ThemeToggle />
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-6 py-12 lg:px-8 lg:py-16">
+        <div className="max-w-2xl">
+          <h1 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+            The shape of Next.js
+          </h1>
+          <p className="mt-3 text-base leading-relaxed text-muted-foreground sm:text-lg">
+            Every module in the Next.js framework core, wired by its real import
+            graph. Graph-sitter parsed{" "}
+            <code className="rounded-md border border-border bg-muted/60 px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">
+              packages/next/src
+            </code>{" "}
+            — {data.meta.files.toLocaleString()} files,{" "}
+            {data.meta.symbols.toLocaleString()} symbols — in{" "}
+            {data.meta.parse_seconds}s.
+          </p>
+        </div>
+
+        <div className="mt-8">
+          <DependencyGraph data={data} />
+        </div>
+
+        <section className="mt-10 grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">
+              Most-depended-on modules
+            </h2>
+            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              Ranked by inbound imports — the modules that the rest of the
+              framework leans on hardest.
+            </p>
+            <ul className="mt-4 overflow-hidden rounded-xl border border-border">
+              {hubs.map((n, i) => (
+                <li
+                  key={n.id}
+                  className="flex items-center gap-3 border-b border-border bg-card px-4 py-2.5 text-sm last:border-b-0"
+                >
+                  <span className="w-4 text-right font-mono text-xs text-muted-foreground">
+                    {i + 1}
+                  </span>
+                  <span className="font-mono text-foreground">{n.id}</span>
+                  <span className="ml-auto font-medium text-foreground">
+                    {n.inbound}
+                  </span>
+                  <span className="text-xs text-muted-foreground">imports</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">
+              How this was built
+            </h2>
+            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              No language server, no IDE — just the graph-sitter Rust backend
+              resolving imports across the whole tree.
+            </p>
+            <pre className="code-surface mt-4 overflow-x-auto px-4 py-3.5 font-mono text-[0.8rem] leading-relaxed">
+              <code>
+                <span className="block">
+                  <span className="text-aura-green">uvx</span> graph-sitter parse
+                  packages/next/src \
+                </span>
+                <span className="block pl-[2ch] text-muted-foreground">
+                  --backend rust --format json
+                </span>
+              </code>
+            </pre>
+            <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+              The resulting graph — {data.meta.modules} modules and{" "}
+              {data.meta.edges} aggregated import edges — is laid out live in
+              your browser with a force simulation.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-border/60">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-8 text-sm text-muted-foreground lg:px-8">
+          <span>Codebase graphs for codemods.</span>
+          <Link href="/docs" className="hover:text-foreground">
+            Read the docs
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -115,6 +115,14 @@ export default function Home() {
 							asChild
 							variant="ghost"
 							size="sm"
+							className="text-muted-foreground hover:text-foreground"
+						>
+							<Link href="/explore">Explore</Link>
+						</Button>
+						<Button
+							asChild
+							variant="ghost"
+							size="sm"
 							className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
 						>
 							<a href={githubUrl} target="_blank" rel="noreferrer">

--- a/site/components/visualizations/dependency-graph.tsx
+++ b/site/components/visualizations/dependency-graph.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  forceCenter,
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  forceX,
+  forceY,
+  type Simulation,
+  type SimulationLinkDatum,
+  type SimulationNodeDatum
+} from "d3-force";
+import { useTheme } from "next-themes";
+
+import { cn } from "@/lib/utils";
+
+export type DepGraphData = {
+  meta: {
+    source: string;
+    parser: string;
+    parse_seconds: number;
+    files: number;
+    modules: number;
+    edges: number;
+    symbols: number;
+  };
+  groups: string[];
+  nodes: {
+    id: string;
+    group: string;
+    files: number;
+    loc: number;
+    symbols: number;
+    inbound: number;
+    outbound: number;
+  }[];
+  edges: { source: string; target: string; weight: number }[];
+};
+
+type GNode = SimulationNodeDatum & DepGraphData["nodes"][number] & { r: number };
+type GLink = SimulationLinkDatum<GNode> & { weight: number };
+
+// Aura-derived palette. Core subsystems get semantic Aura colors; the rest
+// pull from an extended palette so every group stays distinct.
+const GROUP_COLORS: Record<string, string> = {
+  server: "#a277ff",
+  client: "#82e2ff",
+  shared: "#61ffca",
+  build: "#ffca85",
+  lib: "#f694ff",
+  "next-devtools": "#ff6767",
+  export: "#b9a3ff",
+  pages: "#7ee0ff",
+  experimental: "#ffd9a8",
+  telemetry: "#c792ea",
+  trace: "#89ddff",
+  api: "#f78c6c",
+  cli: "#addb67",
+  diagnostics: "#ff9cac",
+  bundles: "#d6bcff",
+  bin: "#9aa5ce",
+  "(root)": "#7c7a89"
+};
+
+const FALLBACK = "#a277ff";
+
+function colorFor(group: string) {
+  return GROUP_COLORS[group] ?? FALLBACK;
+}
+
+export function DependencyGraph({
+  data,
+  className
+}: {
+  data: DepGraphData;
+  className?: string;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme !== "light";
+
+  const [hovered, setHovered] = useState<string | null>(null);
+  const [activeGroups, setActiveGroups] = useState<Set<string>>(new Set());
+
+  // Mutable view state lives in refs so the rAF loop never goes stale.
+  const view = useRef({ x: 0, y: 0, k: 1 });
+  const hoveredRef = useRef<string | null>(null);
+  const activeGroupsRef = useRef<Set<string>>(new Set());
+  const themeRef = useRef(isDark);
+  const tooltip = useRef<{ x: number; y: number } | null>(null);
+  const [, force] = useState(0);
+
+  useEffect(() => {
+    hoveredRef.current = hovered;
+  }, [hovered]);
+  useEffect(() => {
+    activeGroupsRef.current = activeGroups;
+  }, [activeGroups]);
+  useEffect(() => {
+    themeRef.current = isDark;
+  }, [isDark]);
+
+  const { nodes, links, neighbors } = useMemo(() => {
+    const maxIn = Math.max(1, ...data.nodes.map((n) => n.inbound));
+    const nodes: GNode[] = data.nodes.map((n) => ({
+      ...n,
+      r: 5 + (24 * Math.sqrt(n.inbound)) / Math.sqrt(maxIn)
+    }));
+    const links: GLink[] = data.edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      weight: e.weight
+    }));
+    const neighbors = new Map<string, Set<string>>();
+    for (const n of data.nodes) neighbors.set(n.id, new Set());
+    for (const e of data.edges) {
+      neighbors.get(e.source)?.add(e.target);
+      neighbors.get(e.target)?.add(e.source);
+    }
+    return { nodes, links, neighbors };
+  }, [data]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let width = wrap.clientWidth;
+    let height = wrap.clientHeight;
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    const resize = () => {
+      width = wrap.clientWidth;
+      height = wrap.clientHeight;
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    };
+    resize();
+
+    const sim: Simulation<GNode, GLink> = forceSimulation(nodes)
+      .force(
+        "link",
+        forceLink<GNode, GLink>(links)
+          .id((d) => d.id)
+          .distance((l) => 70 + 90 / Math.sqrt(l.weight))
+          .strength((l) => Math.min(0.7, l.weight / 40))
+      )
+      .force(
+        "charge",
+        forceManyBody<GNode>().strength(-420).distanceMax(900)
+      )
+      .force("collide", forceCollide<GNode>((d) => d.r + 8).iterations(2))
+      .force("center", forceCenter(0, 0))
+      .force("x", forceX(0).strength(0.03))
+      .force("y", forceY(0).strength(0.03))
+      .alpha(1)
+      .alphaDecay(0.02);
+
+    sim.stop();
+
+    const toWorld = (sx: number, sy: number) => {
+      const v = view.current;
+      return {
+        x: (sx - width / 2 - v.x) / v.k,
+        y: (sy - height / 2 - v.y) / v.k
+      };
+    };
+
+    const nodeAt = (sx: number, sy: number): GNode | null => {
+      const w = toWorld(sx, sy);
+      let best: GNode | null = null;
+      let bestD = Infinity;
+      for (const n of nodes) {
+        const dx = (n.x ?? 0) - w.x;
+        const dy = (n.y ?? 0) - w.y;
+        const d = dx * dx + dy * dy;
+        const rr = (n.r + 4) * (n.r + 4);
+        if (d < rr && d < bestD) {
+          bestD = d;
+          best = n;
+        }
+      }
+      return best;
+    };
+
+    let raf = 0;
+    const draw = () => {
+      const dark = themeRef.current;
+      const v = view.current;
+      const hov = hoveredRef.current;
+      const groups = activeGroupsRef.current;
+      const hl = neighbors.get(hov ?? "");
+
+      ctx.save();
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(dpr, dpr);
+      ctx.translate(width / 2 + v.x, height / 2 + v.y);
+      ctx.scale(v.k, v.k);
+
+      const dimmed = (id: string, group: string) => {
+        if (groups.size > 0 && !groups.has(group)) return true;
+        if (hov && id !== hov && !(hl && hl.has(id))) return true;
+        return false;
+      };
+
+      // Edges
+      ctx.lineWidth = 0.6 / v.k;
+      for (const l of links) {
+        const s = l.source as GNode;
+        const t = l.target as GNode;
+        if (!s.x || !t.x) continue;
+        const sDim = dimmed(s.id, s.group);
+        const tDim = dimmed(t.id, t.group);
+        const touchesHover = hov && (s.id === hov || t.id === hov);
+        if (touchesHover) {
+          ctx.strokeStyle = colorFor((s.id === hov ? t : s).group);
+          ctx.globalAlpha = 0.55;
+          ctx.lineWidth = Math.max(0.8, Math.min(3, l.weight / 18)) / v.k;
+        } else if (sDim || tDim) {
+          ctx.strokeStyle = dark ? "#edecee" : "#1b1a23";
+          ctx.globalAlpha = 0.03;
+          ctx.lineWidth = 0.6 / v.k;
+        } else {
+          ctx.strokeStyle = dark ? "#edecee" : "#1b1a23";
+          ctx.globalAlpha = 0.09;
+          ctx.lineWidth = 0.6 / v.k;
+        }
+        ctx.beginPath();
+        ctx.moveTo(s.x, s.y!);
+        ctx.lineTo(t.x, t.y!);
+        ctx.stroke();
+      }
+      ctx.globalAlpha = 1;
+
+      // Nodes
+      for (const n of nodes) {
+        if (n.x == null || n.y == null) continue;
+        const dim = dimmed(n.id, n.group);
+        const c = colorFor(n.group);
+        ctx.globalAlpha = dim ? 0.18 : 1;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fillStyle = c;
+        ctx.fill();
+        ctx.lineWidth = 1.5 / v.k;
+        ctx.strokeStyle = dark ? "#15141b" : "#ffffff";
+        ctx.stroke();
+        if (n.id === hov) {
+          ctx.globalAlpha = 1;
+          ctx.lineWidth = 2 / v.k;
+          ctx.strokeStyle = c;
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, n.r + 3 / v.k, 0, Math.PI * 2);
+          ctx.stroke();
+        }
+      }
+
+      // Labels — only for prominent or hovered/neighbor nodes
+      ctx.globalAlpha = 1;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      const fontPx = Math.max(9, 11 / v.k);
+      ctx.font = `${fontPx}px ui-sans-serif, system-ui, sans-serif`;
+      for (const n of nodes) {
+        if (n.x == null || n.y == null) continue;
+        const isHi = n.id === hov || (hl && hl.has(n.id));
+        const big = n.r > 12;
+        if (!isHi && !big) continue;
+        if (groups.size > 0 && !groups.has(n.group)) continue;
+        const label = n.id;
+        ctx.fillStyle = dark ? "#edecee" : "#1b1a23";
+        ctx.globalAlpha = isHi || big ? 0.95 : 0.6;
+        ctx.fillText(label, n.x, n.y + n.r + fontPx);
+      }
+
+      ctx.restore();
+      raf = requestAnimationFrame(draw);
+    };
+
+    // Warm up the layout before first paint so it doesn't visibly explode.
+    for (let i = 0; i < 220; i++) sim.tick();
+    const loop = () => {
+      if (sim.alpha() > 0.005) sim.tick();
+      draw();
+    };
+    raf = requestAnimationFrame(function spin() {
+      loop();
+      raf = requestAnimationFrame(spin);
+    });
+
+    // Interactions
+    let dragNode: GNode | null = null;
+    let panning = false;
+    let last = { x: 0, y: 0 };
+
+    const onMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      if (dragNode) {
+        const w = toWorld(sx, sy);
+        dragNode.fx = w.x;
+        dragNode.fy = w.y;
+        sim.alpha(0.3).restart();
+        tooltip.current = { x: sx, y: sy };
+        return;
+      }
+      if (panning) {
+        view.current.x += sx - last.x;
+        view.current.y += sy - last.y;
+        last = { x: sx, y: sy };
+        return;
+      }
+      const hit = nodeAt(sx, sy);
+      canvas.style.cursor = hit ? "pointer" : "grab";
+      tooltip.current = hit ? { x: sx, y: sy } : null;
+      if ((hit?.id ?? null) !== hoveredRef.current) {
+        setHovered(hit?.id ?? null);
+        force((n) => n + 1);
+      } else if (hit) {
+        force((n) => n + 1);
+      }
+    };
+
+    const onDown = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      const hit = nodeAt(sx, sy);
+      if (hit) {
+        dragNode = hit;
+        hit.fx = hit.x;
+        hit.fy = hit.y;
+        sim.alphaTarget(0.3).restart();
+        canvas.style.cursor = "grabbing";
+      } else {
+        panning = true;
+        last = { x: sx, y: sy };
+        canvas.style.cursor = "grabbing";
+      }
+    };
+
+    const onUp = () => {
+      if (dragNode) {
+        dragNode.fx = null;
+        dragNode.fy = null;
+        sim.alphaTarget(0);
+      }
+      dragNode = null;
+      panning = false;
+      canvas.style.cursor = "grab";
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      const v = view.current;
+      const factor = Math.exp(-e.deltaY * 0.0015);
+      const k = Math.max(0.3, Math.min(4, v.k * factor));
+      const wx = (sx - width / 2 - v.x) / v.k;
+      const wy = (sy - height / 2 - v.y) / v.k;
+      v.k = k;
+      v.x = sx - width / 2 - wx * k;
+      v.y = sy - height / 2 - wy * k;
+    };
+
+    const onLeave = () => {
+      tooltip.current = null;
+      setHovered(null);
+    };
+
+    canvas.addEventListener("mousemove", onMove);
+    canvas.addEventListener("mousedown", onDown);
+    window.addEventListener("mouseup", onUp);
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    canvas.addEventListener("mouseleave", onLeave);
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrap);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      sim.stop();
+      canvas.removeEventListener("mousemove", onMove);
+      canvas.removeEventListener("mousedown", onDown);
+      window.removeEventListener("mouseup", onUp);
+      canvas.removeEventListener("wheel", onWheel);
+      canvas.removeEventListener("mouseleave", onLeave);
+      ro.disconnect();
+    };
+  }, [nodes, links, neighbors]);
+
+  const hoveredNode = hovered
+    ? data.nodes.find((n) => n.id === hovered)
+    : null;
+
+  const toggleGroup = (g: string) => {
+    setActiveGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(g)) next.delete(g);
+      else next.add(g);
+      return next;
+    });
+  };
+
+  return (
+    <div className={cn("not-prose", className)}>
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{data.meta.source}</span>
+          <span>{data.meta.modules} modules</span>
+          <span>{data.meta.edges} import edges</span>
+          <span>{data.meta.files.toLocaleString()} files</span>
+          <span className="text-aura-green">
+            parsed in {data.meta.parse_seconds}s
+          </span>
+        </div>
+
+        <div
+          ref={wrapRef}
+          className="relative h-[34rem] w-full bg-[radial-gradient(circle_at_center,rgba(162,119,255,0.05),transparent_70%)]"
+        >
+          <canvas ref={canvasRef} className="block touch-none" />
+
+          {hoveredNode ? (
+            <div
+              className="pointer-events-none absolute z-10 w-56 rounded-lg border border-border bg-popover/95 p-3 text-xs shadow-xl backdrop-blur"
+              style={{
+                left: Math.min(
+                  (tooltip.current?.x ?? 0) + 14,
+                  (wrapRef.current?.clientWidth ?? 0) - 232
+                ),
+                top: (tooltip.current?.y ?? 0) + 14
+              }}
+            >
+              <div className="mb-1.5 flex items-center gap-2">
+                <span
+                  className="size-2.5 rounded-full"
+                  style={{ background: colorFor(hoveredNode.group) }}
+                />
+                <span className="font-mono font-medium text-foreground">
+                  {hoveredNode.id}
+                </span>
+              </div>
+              <dl className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-muted-foreground">
+                <dt>Imported by</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {hoveredNode.inbound}
+                </dd>
+                <dt>Imports out</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {hoveredNode.outbound}
+                </dd>
+                <dt>Files</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {hoveredNode.files}
+                </dd>
+                <dt>Symbols</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {hoveredNode.symbols.toLocaleString()}
+                </dd>
+                <dt>Lines</dt>
+                <dd className="text-right font-medium text-foreground">
+                  {hoveredNode.loc.toLocaleString()}
+                </dd>
+              </dl>
+            </div>
+          ) : null}
+
+          <div className="pointer-events-none absolute bottom-3 left-3 select-none text-[0.7rem] text-muted-foreground">
+            scroll to zoom · drag a node · drag canvas to pan
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5 border-t border-border px-4 py-3">
+          {data.groups.map((g) => {
+            const on = activeGroups.size === 0 || activeGroups.has(g);
+            return (
+              <button
+                key={g}
+                type="button"
+                onClick={() => toggleGroup(g)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors",
+                  on
+                    ? "border-border bg-secondary text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <span
+                  className="size-2 rounded-full"
+                  style={{ background: colorFor(g), opacity: on ? 1 : 0.4 }}
+                />
+                {g}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/site/components/visualizations/dependency-graph.tsx
+++ b/site/components/visualizations/dependency-graph.tsx
@@ -1,514 +1,512 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  forceCenter,
-  forceCollide,
-  forceLink,
-  forceManyBody,
-  forceSimulation,
-  forceX,
-  forceY,
-  type Simulation,
-  type SimulationLinkDatum,
-  type SimulationNodeDatum
+	type Simulation,
+	type SimulationLinkDatum,
+	type SimulationNodeDatum,
+	forceCenter,
+	forceCollide,
+	forceLink,
+	forceManyBody,
+	forceSimulation,
+	forceX,
+	forceY,
 } from "d3-force";
 import { useTheme } from "next-themes";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
 export type DepGraphData = {
-  meta: {
-    source: string;
-    parser: string;
-    parse_seconds: number;
-    files: number;
-    modules: number;
-    edges: number;
-    symbols: number;
-  };
-  groups: string[];
-  nodes: {
-    id: string;
-    group: string;
-    files: number;
-    loc: number;
-    symbols: number;
-    inbound: number;
-    outbound: number;
-  }[];
-  edges: { source: string; target: string; weight: number }[];
+	meta: {
+		source: string;
+		parser: string;
+		parse_seconds: number;
+		files: number;
+		modules: number;
+		edges: number;
+		symbols: number;
+	};
+	groups: string[];
+	nodes: {
+		id: string;
+		group: string;
+		files: number;
+		loc: number;
+		symbols: number;
+		inbound: number;
+		outbound: number;
+	}[];
+	edges: { source: string; target: string; weight: number }[];
 };
 
-type GNode = SimulationNodeDatum & DepGraphData["nodes"][number] & { r: number };
+type GNode = SimulationNodeDatum &
+	DepGraphData["nodes"][number] & { r: number };
 type GLink = SimulationLinkDatum<GNode> & { weight: number };
 
 // Aura-derived palette. Core subsystems get semantic Aura colors; the rest
 // pull from an extended palette so every group stays distinct.
 const GROUP_COLORS: Record<string, string> = {
-  server: "#a277ff",
-  client: "#82e2ff",
-  shared: "#61ffca",
-  build: "#ffca85",
-  lib: "#f694ff",
-  "next-devtools": "#ff6767",
-  export: "#b9a3ff",
-  pages: "#7ee0ff",
-  experimental: "#ffd9a8",
-  telemetry: "#c792ea",
-  trace: "#89ddff",
-  api: "#f78c6c",
-  cli: "#addb67",
-  diagnostics: "#ff9cac",
-  bundles: "#d6bcff",
-  bin: "#9aa5ce",
-  "(root)": "#7c7a89"
+	server: "#a277ff",
+	client: "#82e2ff",
+	shared: "#61ffca",
+	build: "#ffca85",
+	lib: "#f694ff",
+	"next-devtools": "#ff6767",
+	export: "#b9a3ff",
+	pages: "#7ee0ff",
+	experimental: "#ffd9a8",
+	telemetry: "#c792ea",
+	trace: "#89ddff",
+	api: "#f78c6c",
+	cli: "#addb67",
+	diagnostics: "#ff9cac",
+	bundles: "#d6bcff",
+	bin: "#9aa5ce",
+	"(root)": "#7c7a89",
 };
 
 const FALLBACK = "#a277ff";
 
 function colorFor(group: string) {
-  return GROUP_COLORS[group] ?? FALLBACK;
+	return GROUP_COLORS[group] ?? FALLBACK;
 }
 
 export function DependencyGraph({
-  data,
-  className
+	data,
+	className,
 }: {
-  data: DepGraphData;
-  className?: string;
+	data: DepGraphData;
+	className?: string;
 }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const wrapRef = useRef<HTMLDivElement>(null);
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme !== "light";
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const wrapRef = useRef<HTMLDivElement>(null);
+	const { resolvedTheme } = useTheme();
+	const isDark = resolvedTheme !== "light";
 
-  const [hovered, setHovered] = useState<string | null>(null);
-  const [activeGroups, setActiveGroups] = useState<Set<string>>(new Set());
+	const [hovered, setHovered] = useState<string | null>(null);
+	const [activeGroups, setActiveGroups] = useState<Set<string>>(new Set());
 
-  // Mutable view state lives in refs so the rAF loop never goes stale.
-  const view = useRef({ x: 0, y: 0, k: 1 });
-  const hoveredRef = useRef<string | null>(null);
-  const activeGroupsRef = useRef<Set<string>>(new Set());
-  const themeRef = useRef(isDark);
-  const tooltip = useRef<{ x: number; y: number } | null>(null);
-  const [, force] = useState(0);
+	// Mutable view state lives in refs so the rAF loop never goes stale.
+	const view = useRef({ x: 0, y: 0, k: 1 });
+	const hoveredRef = useRef<string | null>(null);
+	const activeGroupsRef = useRef<Set<string>>(new Set());
+	const themeRef = useRef(isDark);
+	const tooltip = useRef<{ x: number; y: number } | null>(null);
+	const [, force] = useState(0);
 
-  useEffect(() => {
-    hoveredRef.current = hovered;
-  }, [hovered]);
-  useEffect(() => {
-    activeGroupsRef.current = activeGroups;
-  }, [activeGroups]);
-  useEffect(() => {
-    themeRef.current = isDark;
-  }, [isDark]);
+	useEffect(() => {
+		hoveredRef.current = hovered;
+	}, [hovered]);
+	useEffect(() => {
+		activeGroupsRef.current = activeGroups;
+	}, [activeGroups]);
+	useEffect(() => {
+		themeRef.current = isDark;
+	}, [isDark]);
 
-  const { nodes, links, neighbors } = useMemo(() => {
-    const maxIn = Math.max(1, ...data.nodes.map((n) => n.inbound));
-    const nodes: GNode[] = data.nodes.map((n) => ({
-      ...n,
-      r: 5 + (24 * Math.sqrt(n.inbound)) / Math.sqrt(maxIn)
-    }));
-    const links: GLink[] = data.edges.map((e) => ({
-      source: e.source,
-      target: e.target,
-      weight: e.weight
-    }));
-    const neighbors = new Map<string, Set<string>>();
-    for (const n of data.nodes) neighbors.set(n.id, new Set());
-    for (const e of data.edges) {
-      neighbors.get(e.source)?.add(e.target);
-      neighbors.get(e.target)?.add(e.source);
-    }
-    return { nodes, links, neighbors };
-  }, [data]);
+	const { nodes, links, neighbors } = useMemo(() => {
+		const maxIn = Math.max(1, ...data.nodes.map((n) => n.inbound));
+		const nodes: GNode[] = data.nodes.map((n) => ({
+			...n,
+			r: 5 + (24 * Math.sqrt(n.inbound)) / Math.sqrt(maxIn),
+		}));
+		const links: GLink[] = data.edges.map((e) => ({
+			source: e.source,
+			target: e.target,
+			weight: e.weight,
+		}));
+		const neighbors = new Map<string, Set<string>>();
+		for (const n of data.nodes) neighbors.set(n.id, new Set());
+		for (const e of data.edges) {
+			neighbors.get(e.source)?.add(e.target);
+			neighbors.get(e.target)?.add(e.source);
+		}
+		return { nodes, links, neighbors };
+	}, [data]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    const wrap = wrapRef.current;
-    if (!canvas || !wrap) return;
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		const wrap = wrapRef.current;
+		if (!canvas || !wrap) return;
 
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
 
-    let width = wrap.clientWidth;
-    let height = wrap.clientHeight;
-    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+		let width = wrap.clientWidth;
+		let height = wrap.clientHeight;
+		let dpr = Math.min(window.devicePixelRatio || 1, 2);
 
-    const resize = () => {
-      width = wrap.clientWidth;
-      height = wrap.clientHeight;
-      dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = width * dpr;
-      canvas.height = height * dpr;
-      canvas.style.width = `${width}px`;
-      canvas.style.height = `${height}px`;
-    };
-    resize();
+		const resize = () => {
+			width = wrap.clientWidth;
+			height = wrap.clientHeight;
+			dpr = Math.min(window.devicePixelRatio || 1, 2);
+			canvas.width = width * dpr;
+			canvas.height = height * dpr;
+			canvas.style.width = `${width}px`;
+			canvas.style.height = `${height}px`;
+		};
+		resize();
 
-    const sim: Simulation<GNode, GLink> = forceSimulation(nodes)
-      .force(
-        "link",
-        forceLink<GNode, GLink>(links)
-          .id((d) => d.id)
-          .distance((l) => 70 + 90 / Math.sqrt(l.weight))
-          .strength((l) => Math.min(0.7, l.weight / 40))
-      )
-      .force(
-        "charge",
-        forceManyBody<GNode>().strength(-420).distanceMax(900)
-      )
-      .force("collide", forceCollide<GNode>((d) => d.r + 8).iterations(2))
-      .force("center", forceCenter(0, 0))
-      .force("x", forceX(0).strength(0.03))
-      .force("y", forceY(0).strength(0.03))
-      .alpha(1)
-      .alphaDecay(0.02);
+		const sim: Simulation<GNode, GLink> = forceSimulation(nodes)
+			.force(
+				"link",
+				forceLink<GNode, GLink>(links)
+					.id((d) => d.id)
+					.distance((l) => 70 + 90 / Math.sqrt(l.weight))
+					.strength((l) => Math.min(0.7, l.weight / 40)),
+			)
+			.force("charge", forceManyBody<GNode>().strength(-420).distanceMax(900))
+			.force("collide", forceCollide<GNode>((d) => d.r + 8).iterations(2))
+			.force("center", forceCenter(0, 0))
+			.force("x", forceX(0).strength(0.03))
+			.force("y", forceY(0).strength(0.03))
+			.alpha(1)
+			.alphaDecay(0.02);
 
-    sim.stop();
+		sim.stop();
 
-    const toWorld = (sx: number, sy: number) => {
-      const v = view.current;
-      return {
-        x: (sx - width / 2 - v.x) / v.k,
-        y: (sy - height / 2 - v.y) / v.k
-      };
-    };
+		const toWorld = (sx: number, sy: number) => {
+			const v = view.current;
+			return {
+				x: (sx - width / 2 - v.x) / v.k,
+				y: (sy - height / 2 - v.y) / v.k,
+			};
+		};
 
-    const nodeAt = (sx: number, sy: number): GNode | null => {
-      const w = toWorld(sx, sy);
-      let best: GNode | null = null;
-      let bestD = Infinity;
-      for (const n of nodes) {
-        const dx = (n.x ?? 0) - w.x;
-        const dy = (n.y ?? 0) - w.y;
-        const d = dx * dx + dy * dy;
-        const rr = (n.r + 4) * (n.r + 4);
-        if (d < rr && d < bestD) {
-          bestD = d;
-          best = n;
-        }
-      }
-      return best;
-    };
+		const nodeAt = (sx: number, sy: number): GNode | null => {
+			const w = toWorld(sx, sy);
+			let best: GNode | null = null;
+			let bestD = Number.POSITIVE_INFINITY;
+			for (const n of nodes) {
+				const dx = (n.x ?? 0) - w.x;
+				const dy = (n.y ?? 0) - w.y;
+				const d = dx * dx + dy * dy;
+				const rr = (n.r + 4) * (n.r + 4);
+				if (d < rr && d < bestD) {
+					bestD = d;
+					best = n;
+				}
+			}
+			return best;
+		};
 
-    let raf = 0;
-    const draw = () => {
-      const dark = themeRef.current;
-      const v = view.current;
-      const hov = hoveredRef.current;
-      const groups = activeGroupsRef.current;
-      const hl = neighbors.get(hov ?? "");
+		let raf = 0;
+		const draw = () => {
+			const dark = themeRef.current;
+			const v = view.current;
+			const hov = hoveredRef.current;
+			const groups = activeGroupsRef.current;
+			const hl = neighbors.get(hov ?? "");
 
-      ctx.save();
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.scale(dpr, dpr);
-      ctx.translate(width / 2 + v.x, height / 2 + v.y);
-      ctx.scale(v.k, v.k);
+			ctx.save();
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+			ctx.scale(dpr, dpr);
+			ctx.translate(width / 2 + v.x, height / 2 + v.y);
+			ctx.scale(v.k, v.k);
 
-      const dimmed = (id: string, group: string) => {
-        if (groups.size > 0 && !groups.has(group)) return true;
-        if (hov && id !== hov && !(hl && hl.has(id))) return true;
-        return false;
-      };
+			const dimmed = (id: string, group: string) => {
+				if (groups.size > 0 && !groups.has(group)) return true;
+				if (hov && id !== hov && !(hl && hl.has(id))) return true;
+				return false;
+			};
 
-      // Edges
-      ctx.lineWidth = 0.6 / v.k;
-      for (const l of links) {
-        const s = l.source as GNode;
-        const t = l.target as GNode;
-        if (!s.x || !t.x) continue;
-        const sDim = dimmed(s.id, s.group);
-        const tDim = dimmed(t.id, t.group);
-        const touchesHover = hov && (s.id === hov || t.id === hov);
-        if (touchesHover) {
-          ctx.strokeStyle = colorFor((s.id === hov ? t : s).group);
-          ctx.globalAlpha = 0.55;
-          ctx.lineWidth = Math.max(0.8, Math.min(3, l.weight / 18)) / v.k;
-        } else if (sDim || tDim) {
-          ctx.strokeStyle = dark ? "#edecee" : "#1b1a23";
-          ctx.globalAlpha = 0.03;
-          ctx.lineWidth = 0.6 / v.k;
-        } else {
-          ctx.strokeStyle = dark ? "#edecee" : "#1b1a23";
-          ctx.globalAlpha = 0.09;
-          ctx.lineWidth = 0.6 / v.k;
-        }
-        ctx.beginPath();
-        ctx.moveTo(s.x, s.y!);
-        ctx.lineTo(t.x, t.y!);
-        ctx.stroke();
-      }
-      ctx.globalAlpha = 1;
+			// Edges
+			ctx.lineWidth = 0.6 / v.k;
+			for (const l of links) {
+				const s = l.source as GNode;
+				const t = l.target as GNode;
+				if (!s.x || !t.x) continue;
+				const sDim = dimmed(s.id, s.group);
+				const tDim = dimmed(t.id, t.group);
+				const touchesHover = hov && (s.id === hov || t.id === hov);
+				if (touchesHover) {
+					ctx.strokeStyle = colorFor((s.id === hov ? t : s).group);
+					ctx.globalAlpha = 0.55;
+					ctx.lineWidth = Math.max(0.8, Math.min(3, l.weight / 18)) / v.k;
+				} else if (sDim || tDim) {
+					ctx.strokeStyle = dark ? "#edecee" : "#1b1a23";
+					ctx.globalAlpha = 0.03;
+					ctx.lineWidth = 0.6 / v.k;
+				} else {
+					ctx.strokeStyle = dark ? "#edecee" : "#1b1a23";
+					ctx.globalAlpha = 0.09;
+					ctx.lineWidth = 0.6 / v.k;
+				}
+				ctx.beginPath();
+				ctx.moveTo(s.x, s.y!);
+				ctx.lineTo(t.x, t.y!);
+				ctx.stroke();
+			}
+			ctx.globalAlpha = 1;
 
-      // Nodes
-      for (const n of nodes) {
-        if (n.x == null || n.y == null) continue;
-        const dim = dimmed(n.id, n.group);
-        const c = colorFor(n.group);
-        ctx.globalAlpha = dim ? 0.18 : 1;
-        ctx.beginPath();
-        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
-        ctx.fillStyle = c;
-        ctx.fill();
-        ctx.lineWidth = 1.5 / v.k;
-        ctx.strokeStyle = dark ? "#15141b" : "#ffffff";
-        ctx.stroke();
-        if (n.id === hov) {
-          ctx.globalAlpha = 1;
-          ctx.lineWidth = 2 / v.k;
-          ctx.strokeStyle = c;
-          ctx.beginPath();
-          ctx.arc(n.x, n.y, n.r + 3 / v.k, 0, Math.PI * 2);
-          ctx.stroke();
-        }
-      }
+			// Nodes
+			for (const n of nodes) {
+				if (n.x == null || n.y == null) continue;
+				const dim = dimmed(n.id, n.group);
+				const c = colorFor(n.group);
+				ctx.globalAlpha = dim ? 0.18 : 1;
+				ctx.beginPath();
+				ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+				ctx.fillStyle = c;
+				ctx.fill();
+				ctx.lineWidth = 1.5 / v.k;
+				ctx.strokeStyle = dark ? "#15141b" : "#ffffff";
+				ctx.stroke();
+				if (n.id === hov) {
+					ctx.globalAlpha = 1;
+					ctx.lineWidth = 2 / v.k;
+					ctx.strokeStyle = c;
+					ctx.beginPath();
+					ctx.arc(n.x, n.y, n.r + 3 / v.k, 0, Math.PI * 2);
+					ctx.stroke();
+				}
+			}
 
-      // Labels — only for prominent or hovered/neighbor nodes
-      ctx.globalAlpha = 1;
-      ctx.textAlign = "center";
-      ctx.textBaseline = "middle";
-      const fontPx = Math.max(9, 11 / v.k);
-      ctx.font = `${fontPx}px ui-sans-serif, system-ui, sans-serif`;
-      for (const n of nodes) {
-        if (n.x == null || n.y == null) continue;
-        const isHi = n.id === hov || (hl && hl.has(n.id));
-        const big = n.r > 12;
-        if (!isHi && !big) continue;
-        if (groups.size > 0 && !groups.has(n.group)) continue;
-        const label = n.id;
-        ctx.fillStyle = dark ? "#edecee" : "#1b1a23";
-        ctx.globalAlpha = isHi || big ? 0.95 : 0.6;
-        ctx.fillText(label, n.x, n.y + n.r + fontPx);
-      }
+			// Labels — only for prominent or hovered/neighbor nodes
+			ctx.globalAlpha = 1;
+			ctx.textAlign = "center";
+			ctx.textBaseline = "middle";
+			const fontPx = Math.max(9, 11 / v.k);
+			ctx.font = `${fontPx}px ui-sans-serif, system-ui, sans-serif`;
+			for (const n of nodes) {
+				if (n.x == null || n.y == null) continue;
+				const isHi = n.id === hov || (hl && hl.has(n.id));
+				const big = n.r > 12;
+				if (!isHi && !big) continue;
+				if (groups.size > 0 && !groups.has(n.group)) continue;
+				const label = n.id;
+				ctx.fillStyle = dark ? "#edecee" : "#1b1a23";
+				ctx.globalAlpha = isHi || big ? 0.95 : 0.6;
+				ctx.fillText(label, n.x, n.y + n.r + fontPx);
+			}
 
-      ctx.restore();
-      raf = requestAnimationFrame(draw);
-    };
+			ctx.restore();
+			raf = requestAnimationFrame(draw);
+		};
 
-    // Warm up the layout before first paint so it doesn't visibly explode.
-    for (let i = 0; i < 220; i++) sim.tick();
-    const loop = () => {
-      if (sim.alpha() > 0.005) sim.tick();
-      draw();
-    };
-    raf = requestAnimationFrame(function spin() {
-      loop();
-      raf = requestAnimationFrame(spin);
-    });
+		// Warm up the layout before first paint so it doesn't visibly explode.
+		for (let i = 0; i < 220; i++) sim.tick();
+		const loop = () => {
+			if (sim.alpha() > 0.005) sim.tick();
+			draw();
+		};
+		raf = requestAnimationFrame(function spin() {
+			loop();
+			raf = requestAnimationFrame(spin);
+		});
 
-    // Interactions
-    let dragNode: GNode | null = null;
-    let panning = false;
-    let last = { x: 0, y: 0 };
+		// Interactions
+		let dragNode: GNode | null = null;
+		let panning = false;
+		let last = { x: 0, y: 0 };
 
-    const onMove = (e: MouseEvent) => {
-      const rect = canvas.getBoundingClientRect();
-      const sx = e.clientX - rect.left;
-      const sy = e.clientY - rect.top;
-      if (dragNode) {
-        const w = toWorld(sx, sy);
-        dragNode.fx = w.x;
-        dragNode.fy = w.y;
-        sim.alpha(0.3).restart();
-        tooltip.current = { x: sx, y: sy };
-        return;
-      }
-      if (panning) {
-        view.current.x += sx - last.x;
-        view.current.y += sy - last.y;
-        last = { x: sx, y: sy };
-        return;
-      }
-      const hit = nodeAt(sx, sy);
-      canvas.style.cursor = hit ? "pointer" : "grab";
-      tooltip.current = hit ? { x: sx, y: sy } : null;
-      if ((hit?.id ?? null) !== hoveredRef.current) {
-        setHovered(hit?.id ?? null);
-        force((n) => n + 1);
-      } else if (hit) {
-        force((n) => n + 1);
-      }
-    };
+		const onMove = (e: MouseEvent) => {
+			const rect = canvas.getBoundingClientRect();
+			const sx = e.clientX - rect.left;
+			const sy = e.clientY - rect.top;
+			if (dragNode) {
+				const w = toWorld(sx, sy);
+				dragNode.fx = w.x;
+				dragNode.fy = w.y;
+				sim.alpha(0.3).restart();
+				tooltip.current = { x: sx, y: sy };
+				return;
+			}
+			if (panning) {
+				view.current.x += sx - last.x;
+				view.current.y += sy - last.y;
+				last = { x: sx, y: sy };
+				return;
+			}
+			const hit = nodeAt(sx, sy);
+			canvas.style.cursor = hit ? "pointer" : "grab";
+			tooltip.current = hit ? { x: sx, y: sy } : null;
+			if ((hit?.id ?? null) !== hoveredRef.current) {
+				setHovered(hit?.id ?? null);
+				force((n) => n + 1);
+			} else if (hit) {
+				force((n) => n + 1);
+			}
+		};
 
-    const onDown = (e: MouseEvent) => {
-      const rect = canvas.getBoundingClientRect();
-      const sx = e.clientX - rect.left;
-      const sy = e.clientY - rect.top;
-      const hit = nodeAt(sx, sy);
-      if (hit) {
-        dragNode = hit;
-        hit.fx = hit.x;
-        hit.fy = hit.y;
-        sim.alphaTarget(0.3).restart();
-        canvas.style.cursor = "grabbing";
-      } else {
-        panning = true;
-        last = { x: sx, y: sy };
-        canvas.style.cursor = "grabbing";
-      }
-    };
+		const onDown = (e: MouseEvent) => {
+			const rect = canvas.getBoundingClientRect();
+			const sx = e.clientX - rect.left;
+			const sy = e.clientY - rect.top;
+			const hit = nodeAt(sx, sy);
+			if (hit) {
+				dragNode = hit;
+				hit.fx = hit.x;
+				hit.fy = hit.y;
+				sim.alphaTarget(0.3).restart();
+				canvas.style.cursor = "grabbing";
+			} else {
+				panning = true;
+				last = { x: sx, y: sy };
+				canvas.style.cursor = "grabbing";
+			}
+		};
 
-    const onUp = () => {
-      if (dragNode) {
-        dragNode.fx = null;
-        dragNode.fy = null;
-        sim.alphaTarget(0);
-      }
-      dragNode = null;
-      panning = false;
-      canvas.style.cursor = "grab";
-    };
+		const onUp = () => {
+			if (dragNode) {
+				dragNode.fx = null;
+				dragNode.fy = null;
+				sim.alphaTarget(0);
+			}
+			dragNode = null;
+			panning = false;
+			canvas.style.cursor = "grab";
+		};
 
-    const onWheel = (e: WheelEvent) => {
-      e.preventDefault();
-      const rect = canvas.getBoundingClientRect();
-      const sx = e.clientX - rect.left;
-      const sy = e.clientY - rect.top;
-      const v = view.current;
-      const factor = Math.exp(-e.deltaY * 0.0015);
-      const k = Math.max(0.3, Math.min(4, v.k * factor));
-      const wx = (sx - width / 2 - v.x) / v.k;
-      const wy = (sy - height / 2 - v.y) / v.k;
-      v.k = k;
-      v.x = sx - width / 2 - wx * k;
-      v.y = sy - height / 2 - wy * k;
-    };
+		const onWheel = (e: WheelEvent) => {
+			e.preventDefault();
+			const rect = canvas.getBoundingClientRect();
+			const sx = e.clientX - rect.left;
+			const sy = e.clientY - rect.top;
+			const v = view.current;
+			const factor = Math.exp(-e.deltaY * 0.0015);
+			const k = Math.max(0.3, Math.min(4, v.k * factor));
+			const wx = (sx - width / 2 - v.x) / v.k;
+			const wy = (sy - height / 2 - v.y) / v.k;
+			v.k = k;
+			v.x = sx - width / 2 - wx * k;
+			v.y = sy - height / 2 - wy * k;
+		};
 
-    const onLeave = () => {
-      tooltip.current = null;
-      setHovered(null);
-    };
+		const onLeave = () => {
+			tooltip.current = null;
+			setHovered(null);
+		};
 
-    canvas.addEventListener("mousemove", onMove);
-    canvas.addEventListener("mousedown", onDown);
-    window.addEventListener("mouseup", onUp);
-    canvas.addEventListener("wheel", onWheel, { passive: false });
-    canvas.addEventListener("mouseleave", onLeave);
+		canvas.addEventListener("mousemove", onMove);
+		canvas.addEventListener("mousedown", onDown);
+		window.addEventListener("mouseup", onUp);
+		canvas.addEventListener("wheel", onWheel, { passive: false });
+		canvas.addEventListener("mouseleave", onLeave);
 
-    const ro = new ResizeObserver(resize);
-    ro.observe(wrap);
+		const ro = new ResizeObserver(resize);
+		ro.observe(wrap);
 
-    return () => {
-      cancelAnimationFrame(raf);
-      sim.stop();
-      canvas.removeEventListener("mousemove", onMove);
-      canvas.removeEventListener("mousedown", onDown);
-      window.removeEventListener("mouseup", onUp);
-      canvas.removeEventListener("wheel", onWheel);
-      canvas.removeEventListener("mouseleave", onLeave);
-      ro.disconnect();
-    };
-  }, [nodes, links, neighbors]);
+		return () => {
+			cancelAnimationFrame(raf);
+			sim.stop();
+			canvas.removeEventListener("mousemove", onMove);
+			canvas.removeEventListener("mousedown", onDown);
+			window.removeEventListener("mouseup", onUp);
+			canvas.removeEventListener("wheel", onWheel);
+			canvas.removeEventListener("mouseleave", onLeave);
+			ro.disconnect();
+		};
+	}, [nodes, links, neighbors]);
 
-  const hoveredNode = hovered
-    ? data.nodes.find((n) => n.id === hovered)
-    : null;
+	const hoveredNode = hovered ? data.nodes.find((n) => n.id === hovered) : null;
 
-  const toggleGroup = (g: string) => {
-    setActiveGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(g)) next.delete(g);
-      else next.add(g);
-      return next;
-    });
-  };
+	const toggleGroup = (g: string) => {
+		setActiveGroups((prev) => {
+			const next = new Set(prev);
+			if (next.has(g)) next.delete(g);
+			else next.add(g);
+			return next;
+		});
+	};
 
-  return (
-    <div className={cn("not-prose", className)}>
-      <div className="overflow-hidden rounded-xl border border-border bg-card">
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">{data.meta.source}</span>
-          <span>{data.meta.modules} modules</span>
-          <span>{data.meta.edges} import edges</span>
-          <span>{data.meta.files.toLocaleString()} files</span>
-          <span className="text-aura-green">
-            parsed in {data.meta.parse_seconds}s
-          </span>
-        </div>
+	return (
+		<div className={cn("not-prose", className)}>
+			<div className="overflow-hidden rounded-xl border border-border bg-card">
+				<div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+					<span className="font-medium text-foreground">
+						{data.meta.source}
+					</span>
+					<span>{data.meta.modules} modules</span>
+					<span>{data.meta.edges} import edges</span>
+					<span>{data.meta.files.toLocaleString()} files</span>
+					<span className="text-aura-green">
+						parsed in {data.meta.parse_seconds}s
+					</span>
+				</div>
 
-        <div
-          ref={wrapRef}
-          className="relative h-[34rem] w-full bg-[radial-gradient(circle_at_center,rgba(162,119,255,0.05),transparent_70%)]"
-        >
-          <canvas ref={canvasRef} className="block touch-none" />
+				<div
+					ref={wrapRef}
+					className="relative h-[34rem] w-full bg-[radial-gradient(circle_at_center,rgba(162,119,255,0.05),transparent_70%)]"
+				>
+					<canvas ref={canvasRef} className="block touch-none" />
 
-          {hoveredNode ? (
-            <div
-              className="pointer-events-none absolute z-10 w-56 rounded-lg border border-border bg-popover/95 p-3 text-xs shadow-xl backdrop-blur"
-              style={{
-                left: Math.min(
-                  (tooltip.current?.x ?? 0) + 14,
-                  (wrapRef.current?.clientWidth ?? 0) - 232
-                ),
-                top: (tooltip.current?.y ?? 0) + 14
-              }}
-            >
-              <div className="mb-1.5 flex items-center gap-2">
-                <span
-                  className="size-2.5 rounded-full"
-                  style={{ background: colorFor(hoveredNode.group) }}
-                />
-                <span className="font-mono font-medium text-foreground">
-                  {hoveredNode.id}
-                </span>
-              </div>
-              <dl className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-muted-foreground">
-                <dt>Imported by</dt>
-                <dd className="text-right font-medium text-foreground">
-                  {hoveredNode.inbound}
-                </dd>
-                <dt>Imports out</dt>
-                <dd className="text-right font-medium text-foreground">
-                  {hoveredNode.outbound}
-                </dd>
-                <dt>Files</dt>
-                <dd className="text-right font-medium text-foreground">
-                  {hoveredNode.files}
-                </dd>
-                <dt>Symbols</dt>
-                <dd className="text-right font-medium text-foreground">
-                  {hoveredNode.symbols.toLocaleString()}
-                </dd>
-                <dt>Lines</dt>
-                <dd className="text-right font-medium text-foreground">
-                  {hoveredNode.loc.toLocaleString()}
-                </dd>
-              </dl>
-            </div>
-          ) : null}
+					{hoveredNode ? (
+						<div
+							className="pointer-events-none absolute z-10 w-56 rounded-lg border border-border bg-popover/95 p-3 text-xs shadow-xl backdrop-blur"
+							style={{
+								left: Math.min(
+									(tooltip.current?.x ?? 0) + 14,
+									(wrapRef.current?.clientWidth ?? 0) - 232,
+								),
+								top: (tooltip.current?.y ?? 0) + 14,
+							}}
+						>
+							<div className="mb-1.5 flex items-center gap-2">
+								<span
+									className="size-2.5 rounded-full"
+									style={{ background: colorFor(hoveredNode.group) }}
+								/>
+								<span className="font-mono font-medium text-foreground">
+									{hoveredNode.id}
+								</span>
+							</div>
+							<dl className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-muted-foreground">
+								<dt>Imported by</dt>
+								<dd className="text-right font-medium text-foreground">
+									{hoveredNode.inbound}
+								</dd>
+								<dt>Imports out</dt>
+								<dd className="text-right font-medium text-foreground">
+									{hoveredNode.outbound}
+								</dd>
+								<dt>Files</dt>
+								<dd className="text-right font-medium text-foreground">
+									{hoveredNode.files}
+								</dd>
+								<dt>Symbols</dt>
+								<dd className="text-right font-medium text-foreground">
+									{hoveredNode.symbols.toLocaleString()}
+								</dd>
+								<dt>Lines</dt>
+								<dd className="text-right font-medium text-foreground">
+									{hoveredNode.loc.toLocaleString()}
+								</dd>
+							</dl>
+						</div>
+					) : null}
 
-          <div className="pointer-events-none absolute bottom-3 left-3 select-none text-[0.7rem] text-muted-foreground">
-            scroll to zoom · drag a node · drag canvas to pan
-          </div>
-        </div>
+					<div className="pointer-events-none absolute bottom-3 left-3 select-none text-[0.7rem] text-muted-foreground">
+						scroll to zoom · drag a node · drag canvas to pan
+					</div>
+				</div>
 
-        <div className="flex flex-wrap gap-1.5 border-t border-border px-4 py-3">
-          {data.groups.map((g) => {
-            const on = activeGroups.size === 0 || activeGroups.has(g);
-            return (
-              <button
-                key={g}
-                type="button"
-                onClick={() => toggleGroup(g)}
-                className={cn(
-                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors",
-                  on
-                    ? "border-border bg-secondary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground"
-                )}
-              >
-                <span
-                  className="size-2 rounded-full"
-                  style={{ background: colorFor(g), opacity: on ? 1 : 0.4 }}
-                />
-                {g}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
+				<div className="flex flex-wrap gap-1.5 border-t border-border px-4 py-3">
+					{data.groups.map((g) => {
+						const on = activeGroups.size === 0 || activeGroups.has(g);
+						return (
+							<button
+								key={g}
+								type="button"
+								onClick={() => toggleGroup(g)}
+								className={cn(
+									"inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors",
+									on
+										? "border-border bg-secondary text-foreground"
+										: "border-transparent text-muted-foreground hover:text-foreground",
+								)}
+							>
+								<span
+									className="size-2 rounded-full"
+									style={{ background: colorFor(g), opacity: on ? 1 : 0.4 }}
+								/>
+								{g}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/site/lib/data/nextjs-depgraph.json
+++ b/site/lib/data/nextjs-depgraph.json
@@ -1,4403 +1,4403 @@
 {
-  "meta": {
-    "source": "vercel/next.js \u00b7 packages/next/src",
-    "parser": "graph-sitter (rust backend)",
-    "parse_seconds": 4.89,
-    "files": 1680,
-    "modules": 91,
-    "edges": 710,
-    "symbols": 16004
-  },
-  "groups": [
-    "(root)",
-    "api",
-    "bin",
-    "build",
-    "bundles",
-    "cli",
-    "client",
-    "diagnostics",
-    "experimental",
-    "export",
-    "lib",
-    "next-devtools",
-    "pages",
-    "server",
-    "shared",
-    "telemetry",
-    "trace"
-  ],
-  "nodes": [
-    {
-      "id": "(root)",
-      "group": "(root)",
-      "files": 1,
-      "loc": 327,
-      "symbols": 20,
-      "inbound": 42,
-      "outbound": 24
-    },
-    {
-      "id": "api",
-      "group": "api",
-      "files": 18,
-      "loc": 39,
-      "symbols": 1,
-      "inbound": 1,
-      "outbound": 33
-    },
-    {
-      "id": "bin",
-      "group": "bin",
-      "files": 1,
-      "loc": 763,
-      "symbols": 11,
-      "inbound": 0,
-      "outbound": 10
-    },
-    {
-      "id": "build",
-      "group": "build",
-      "files": 43,
-      "loc": 16061,
-      "symbols": 978,
-      "inbound": 164,
-      "outbound": 491
-    },
-    {
-      "id": "build/adapter",
-      "group": "build",
-      "files": 2,
-      "loc": 2427,
-      "symbols": 60,
-      "inbound": 6,
-      "outbound": 39
-    },
-    {
-      "id": "build/analysis",
-      "group": "build",
-      "files": 4,
-      "loc": 1280,
-      "symbols": 63,
-      "inbound": 29,
-      "outbound": 36
-    },
-    {
-      "id": "build/analyze",
-      "group": "build",
-      "files": 1,
-      "loc": 234,
-      "symbols": 10,
-      "inbound": 1,
-      "outbound": 20
-    },
-    {
-      "id": "build/babel",
-      "group": "build",
-      "files": 14,
-      "loc": 2353,
-      "symbols": 114,
-      "inbound": 1,
-      "outbound": 10
-    },
-    {
-      "id": "build/jest",
-      "group": "build",
-      "files": 6,
-      "loc": 286,
-      "symbols": 26,
-      "inbound": 0,
-      "outbound": 8
-    },
-    {
-      "id": "build/manifests",
-      "group": "build",
-      "files": 1,
-      "loc": 8,
-      "symbols": 1,
-      "inbound": 2,
-      "outbound": 0
-    },
-    {
-      "id": "build/next-config-ts",
-      "group": "build",
-      "files": 2,
-      "loc": 297,
-      "symbols": 16,
-      "inbound": 1,
-      "outbound": 3
-    },
-    {
-      "id": "build/output",
-      "group": "build",
-      "files": 4,
-      "loc": 566,
-      "symbols": 45,
-      "inbound": 87,
-      "outbound": 15
-    },
-    {
-      "id": "build/polyfills",
-      "group": "build",
-      "files": 10,
-      "loc": 36,
-      "symbols": 4,
-      "inbound": 2,
-      "outbound": 0
-    },
-    {
-      "id": "build/segment-config",
-      "group": "build",
-      "files": 5,
-      "loc": 805,
-      "symbols": 41,
-      "inbound": 38,
-      "outbound": 21
-    },
-    {
-      "id": "build/static-paths",
-      "group": "build",
-      "files": 8,
-      "loc": 5709,
-      "symbols": 62,
-      "inbound": 16,
-      "outbound": 58
-    },
-    {
-      "id": "build/swc",
-      "group": "build",
-      "files": 9,
-      "loc": 3974,
-      "symbols": 239,
-      "inbound": 95,
-      "outbound": 25
-    },
-    {
-      "id": "build/templates",
-      "group": "build",
-      "files": 11,
-      "loc": 4190,
-      "symbols": 188,
-      "inbound": 0,
-      "outbound": 189
-    },
-    {
-      "id": "build/turbopack-analyze",
-      "group": "build",
-      "files": 1,
-      "loc": 130,
-      "symbols": 4,
-      "inbound": 2,
-      "outbound": 11
-    },
-    {
-      "id": "build/turbopack-build",
-      "group": "build",
-      "files": 2,
-      "loc": 467,
-      "symbols": 8,
-      "inbound": 1,
-      "outbound": 33
-    },
-    {
-      "id": "build/turborepo-access-trace",
-      "group": "build",
-      "files": 6,
-      "loc": 289,
-      "symbols": 14,
-      "inbound": 8,
-      "outbound": 0
-    },
-    {
-      "id": "build/webpack",
-      "group": "build",
-      "files": 140,
-      "loc": 21358,
-      "symbols": 1965,
-      "inbound": 113,
-      "outbound": 285
-    },
-    {
-      "id": "build/webpack-build",
-      "group": "build",
-      "files": 2,
-      "loc": 623,
-      "symbols": 33,
-      "inbound": 1,
-      "outbound": 45
-    },
-    {
-      "id": "build/webpack-config-rules",
-      "group": "build",
-      "files": 1,
-      "loc": 30,
-      "symbols": 3,
-      "inbound": 2,
-      "outbound": 2
-    },
-    {
-      "id": "bundles",
-      "group": "bundles",
-      "files": 1,
-      "loc": 7,
-      "symbols": 1,
-      "inbound": 0,
-      "outbound": 0
-    },
-    {
-      "id": "bundles/babel",
-      "group": "bundles",
-      "files": 29,
-      "loc": 255,
-      "symbols": 44,
-      "inbound": 0,
-      "outbound": 0
-    },
-    {
-      "id": "bundles/cssnano-simple",
-      "group": "bundles",
-      "files": 3,
-      "loc": 203,
-      "symbols": 7,
-      "inbound": 0,
-      "outbound": 0
-    },
-    {
-      "id": "bundles/postcss-plugin-stub",
-      "group": "bundles",
-      "files": 1,
-      "loc": 25,
-      "symbols": 1,
-      "inbound": 0,
-      "outbound": 0
-    },
-    {
-      "id": "bundles/webpack",
-      "group": "bundles",
-      "files": 26,
-      "loc": 1114,
-      "symbols": 40,
-      "inbound": 0,
-      "outbound": 0
-    },
-    {
-      "id": "cli",
-      "group": "cli",
-      "files": 11,
-      "loc": 1981,
-      "symbols": 208,
-      "inbound": 2,
-      "outbound": 114
-    },
-    {
-      "id": "cli/internal",
-      "group": "cli",
-      "files": 4,
-      "loc": 1819,
-      "symbols": 104,
-      "inbound": 0,
-      "outbound": 4
-    },
-    {
-      "id": "client",
-      "group": "client",
-      "files": 53,
-      "loc": 6685,
-      "symbols": 470,
-      "inbound": 92,
-      "outbound": 167
-    },
-    {
-      "id": "client/app-dir",
-      "group": "client",
-      "files": 3,
-      "loc": 1090,
-      "symbols": 25,
-      "inbound": 0,
-      "outbound": 30
-    },
-    {
-      "id": "client/compat",
-      "group": "client",
-      "files": 1,
-      "loc": 17,
-      "symbols": 1,
-      "inbound": 0,
-      "outbound": 2
-    },
-    {
-      "id": "client/components",
-      "group": "client",
-      "files": 103,
-      "loc": 20577,
-      "symbols": 786,
-      "inbound": 215,
-      "outbound": 244
-    },
-    {
-      "id": "client/dev",
-      "group": "client",
-      "files": 15,
-      "loc": 2544,
-      "symbols": 154,
-      "inbound": 14,
-      "outbound": 49
-    },
-    {
-      "id": "client/legacy",
-      "group": "client",
-      "files": 1,
-      "loc": 1202,
-      "symbols": 57,
-      "inbound": 0,
-      "outbound": 12
-    },
-    {
-      "id": "client/lib",
-      "group": "client",
-      "files": 3,
-      "loc": 225,
-      "symbols": 9,
-      "inbound": 9,
-      "outbound": 2
-    },
-    {
-      "id": "client/portal",
-      "group": "client",
-      "files": 1,
-      "loc": 22,
-      "symbols": 5,
-      "inbound": 1,
-      "outbound": 0
-    },
-    {
-      "id": "client/react-client-callbacks",
-      "group": "client",
-      "files": 3,
-      "loc": 170,
-      "symbols": 12,
-      "inbound": 7,
-      "outbound": 7
-    },
-    {
-      "id": "client/request",
-      "group": "client",
-      "files": 7,
-      "loc": 262,
-      "symbols": 27,
-      "inbound": 0,
-      "outbound": 11
-    },
-    {
-      "id": "client/tracing",
-      "group": "client",
-      "files": 2,
-      "loc": 97,
-      "symbols": 6,
-      "inbound": 1,
-      "outbound": 3
-    },
-    {
-      "id": "diagnostics",
-      "group": "diagnostics",
-      "files": 2,
-      "loc": 183,
-      "symbols": 13,
-      "inbound": 3,
-      "outbound": 4
-    },
-    {
-      "id": "experimental/testing",
-      "group": "experimental",
-      "files": 6,
-      "loc": 902,
-      "symbols": 12,
-      "inbound": 0,
-      "outbound": 25
-    },
-    {
-      "id": "experimental/testmode",
-      "group": "experimental",
-      "files": 18,
-      "loc": 1035,
-      "symbols": 95,
-      "inbound": 0,
-      "outbound": 2
-    },
-    {
-      "id": "export",
-      "group": "export",
-      "files": 4,
-      "loc": 1951,
-      "symbols": 80,
-      "inbound": 8,
-      "outbound": 112
-    },
-    {
-      "id": "export/helpers",
-      "group": "export",
-      "files": 3,
-      "loc": 130,
-      "symbols": 4,
-      "inbound": 9,
-      "outbound": 14
-    },
-    {
-      "id": "export/routes",
-      "group": "export",
-      "files": 4,
-      "loc": 626,
-      "symbols": 6,
-      "inbound": 5,
-      "outbound": 66
-    },
-    {
-      "id": "lib",
-      "group": "lib",
-      "files": 79,
-      "loc": 8684,
-      "symbols": 432,
-      "inbound": 694,
-      "outbound": 68
-    },
-    {
-      "id": "lib/framework",
-      "group": "lib",
-      "files": 2,
-      "loc": 56,
-      "symbols": 9,
-      "inbound": 9,
-      "outbound": 0
-    },
-    {
-      "id": "lib/fs",
-      "group": "lib",
-      "files": 2,
-      "loc": 130,
-      "symbols": 3,
-      "inbound": 1,
-      "outbound": 0
-    },
-    {
-      "id": "lib/helpers",
-      "group": "lib",
-      "files": 8,
-      "loc": 413,
-      "symbols": 17,
-      "inbound": 20,
-      "outbound": 2
-    },
-    {
-      "id": "lib/memory",
-      "group": "lib",
-      "files": 4,
-      "loc": 240,
-      "symbols": 19,
-      "inbound": 4,
-      "outbound": 14
-    },
-    {
-      "id": "lib/metadata",
-      "group": "lib",
-      "files": 29,
-      "loc": 8357,
-      "symbols": 303,
-      "inbound": 47,
-      "outbound": 51
-    },
-    {
-      "id": "lib/typescript",
-      "group": "lib",
-      "files": 9,
-      "loc": 1624,
-      "symbols": 53,
-      "inbound": 6,
-      "outbound": 21
-    },
-    {
-      "id": "next-devtools",
-      "group": "next-devtools",
-      "files": 4,
-      "loc": 494,
-      "symbols": 24,
-      "inbound": 14,
-      "outbound": 39
-    },
-    {
-      "id": "next-devtools/dev-overlay",
-      "group": "next-devtools",
-      "files": 158,
-      "loc": 19418,
-      "symbols": 1100,
-      "inbound": 48,
-      "outbound": 93
-    },
-    {
-      "id": "next-devtools/server",
-      "group": "next-devtools",
-      "files": 11,
-      "loc": 1090,
-      "symbols": 65,
-      "inbound": 41,
-      "outbound": 18
-    },
-    {
-      "id": "next-devtools/shared",
-      "group": "next-devtools",
-      "files": 12,
-      "loc": 658,
-      "symbols": 47,
-      "inbound": 55,
-      "outbound": 7
-    },
-    {
-      "id": "next-devtools/userspace",
-      "group": "next-devtools",
-      "files": 17,
-      "loc": 1573,
-      "symbols": 144,
-      "inbound": 18,
-      "outbound": 39
-    },
-    {
-      "id": "pages",
-      "group": "pages",
-      "files": 3,
-      "loc": 1211,
-      "symbols": 120,
-      "inbound": 9,
-      "outbound": 28
-    },
-    {
-      "id": "server",
-      "group": "server",
-      "files": 55,
-      "loc": 20000,
-      "symbols": 994,
-      "inbound": 447,
-      "outbound": 497
-    },
-    {
-      "id": "server/after",
-      "group": "server",
-      "files": 8,
-      "loc": 1176,
-      "symbols": 32,
-      "inbound": 16,
-      "outbound": 19
-    },
-    {
-      "id": "server/api-utils",
-      "group": "server",
-      "files": 6,
-      "loc": 932,
-      "symbols": 37,
-      "inbound": 38,
-      "outbound": 28
-    },
-    {
-      "id": "server/app-render",
-      "group": "server",
-      "files": 88,
-      "loc": 26740,
-      "symbols": 1371,
-      "inbound": 322,
-      "outbound": 437
-    },
-    {
-      "id": "server/async-storage",
-      "group": "server",
-      "files": 4,
-      "loc": 629,
-      "symbols": 22,
-      "inbound": 13,
-      "outbound": 43
-    },
-    {
-      "id": "server/base-http",
-      "group": "server",
-      "files": 5,
-      "loc": 504,
-      "symbols": 23,
-      "inbound": 66,
-      "outbound": 14
-    },
-    {
-      "id": "server/dev",
-      "group": "server",
-      "files": 31,
-      "loc": 12369,
-      "symbols": 782,
-      "inbound": 63,
-      "outbound": 401
-    },
-    {
-      "id": "server/instrumentation",
-      "group": "server",
-      "files": 2,
-      "loc": 42,
-      "symbols": 6,
-      "inbound": 16,
-      "outbound": 0
-    },
-    {
-      "id": "server/lib",
-      "group": "server",
-      "files": 94,
-      "loc": 17745,
-      "symbols": 1208,
-      "inbound": 378,
-      "outbound": 354
-    },
-    {
-      "id": "server/mcp",
-      "group": "server",
-      "files": 17,
-      "loc": 1780,
-      "symbols": 112,
-      "inbound": 13,
-      "outbound": 26
-    },
-    {
-      "id": "server/node-environment-extensions",
-      "group": "server",
-      "files": 17,
-      "loc": 6111,
-      "symbols": 176,
-      "inbound": 16,
-      "outbound": 30
-    },
-    {
-      "id": "server/normalizers",
-      "group": "server",
-      "files": 30,
-      "loc": 745,
-      "symbols": 38,
-      "inbound": 27,
-      "outbound": 18
-    },
-    {
-      "id": "server/og",
-      "group": "server",
-      "files": 1,
-      "loc": 64,
-      "symbols": 12,
-      "inbound": 1,
-      "outbound": 0
-    },
-    {
-      "id": "server/request",
-      "group": "server",
-      "files": 12,
-      "loc": 4140,
-      "symbols": 132,
-      "inbound": 89,
-      "outbound": 172
-    },
-    {
-      "id": "server/response-cache",
-      "group": "server",
-      "files": 5,
-      "loc": 1142,
-      "symbols": 78,
-      "inbound": 63,
-      "outbound": 16
-    },
-    {
-      "id": "server/resume-data-cache",
-      "group": "server",
-      "files": 3,
-      "loc": 654,
-      "symbols": 22,
-      "inbound": 21,
-      "outbound": 7
-    },
-    {
-      "id": "server/route-definitions",
-      "group": "server",
-      "files": 6,
-      "loc": 66,
-      "symbols": 7,
-      "inbound": 38,
-      "outbound": 6
-    },
-    {
-      "id": "server/route-matcher-managers",
-      "group": "server",
-      "files": 4,
-      "loc": 796,
-      "symbols": 33,
-      "inbound": 7,
-      "outbound": 27
-    },
-    {
-      "id": "server/route-matcher-providers",
-      "group": "server",
-      "files": 27,
-      "loc": 1863,
-      "symbols": 98,
-      "inbound": 15,
-      "outbound": 81
-    },
-    {
-      "id": "server/route-matchers",
-      "group": "server",
-      "files": 6,
-      "loc": 177,
-      "symbols": 13,
-      "inbound": 22,
-      "outbound": 14
-    },
-    {
-      "id": "server/route-matches",
-      "group": "server",
-      "files": 6,
-      "loc": 56,
-      "symbols": 7,
-      "inbound": 10,
-      "outbound": 8
-    },
-    {
-      "id": "server/route-modules",
-      "group": "server",
-      "files": 64,
-      "loc": 4996,
-      "symbols": 371,
-      "inbound": 64,
-      "outbound": 246
-    },
-    {
-      "id": "server/stream-utils",
-      "group": "server",
-      "files": 4,
-      "loc": 1471,
-      "symbols": 141,
-      "inbound": 40,
-      "outbound": 13
-    },
-    {
-      "id": "server/typescript",
-      "group": "server",
-      "files": 10,
-      "loc": 2140,
-      "symbols": 240,
-      "inbound": 1,
-      "outbound": 1
-    },
-    {
-      "id": "server/use-cache",
-      "group": "server",
-      "files": 10,
-      "loc": 4423,
-      "symbols": 142,
-      "inbound": 27,
-      "outbound": 68
-    },
-    {
-      "id": "server/web",
-      "group": "server",
-      "files": 36,
-      "loc": 4955,
-      "symbols": 283,
-      "inbound": 119,
-      "outbound": 114
-    },
-    {
-      "id": "shared/lib",
-      "group": "shared",
-      "files": 164,
-      "loc": 17875,
-      "symbols": 1037,
-      "inbound": 1393,
-      "outbound": 123
-    },
-    {
-      "id": "telemetry",
-      "group": "telemetry",
-      "files": 8,
-      "loc": 714,
-      "symbols": 40,
-      "inbound": 22,
-      "outbound": 9
-    },
-    {
-      "id": "telemetry/events",
-      "group": "telemetry",
-      "files": 10,
-      "loc": 889,
-      "symbols": 57,
-      "inbound": 22,
-      "outbound": 8
-    },
-    {
-      "id": "trace",
-      "group": "trace",
-      "files": 7,
-      "loc": 769,
-      "symbols": 56,
-      "inbound": 88,
-      "outbound": 4
-    },
-    {
-      "id": "trace/report",
-      "group": "trace",
-      "files": 6,
-      "loc": 325,
-      "symbols": 25,
-      "inbound": 1,
-      "outbound": 12
-    }
-  ],
-  "edges": [
-    {
-      "source": "server",
-      "target": "shared/lib",
-      "weight": 175
-    },
-    {
-      "source": "client/components",
-      "target": "shared/lib",
-      "weight": 171
-    },
-    {
-      "source": "server/app-render",
-      "target": "shared/lib",
-      "weight": 133
-    },
-    {
-      "source": "build",
-      "target": "lib",
-      "weight": 128
-    },
-    {
-      "source": "build",
-      "target": "shared/lib",
-      "weight": 114
-    },
-    {
-      "source": "client",
-      "target": "shared/lib",
-      "weight": 114
-    },
-    {
-      "source": "server/lib",
-      "target": "shared/lib",
-      "weight": 107
-    },
-    {
-      "source": "server/request",
-      "target": "server/app-render",
-      "weight": 100
-    },
-    {
-      "source": "build/webpack",
-      "target": "shared/lib",
-      "weight": 94
-    },
-    {
-      "source": "server/dev",
-      "target": "shared/lib",
-      "weight": 78
-    },
-    {
-      "source": "server",
-      "target": "server/lib",
-      "weight": 72
-    },
-    {
-      "source": "build/webpack",
-      "target": "lib",
-      "weight": 71
-    },
-    {
-      "source": "server",
-      "target": "lib",
-      "weight": 68
-    },
-    {
-      "source": "server/app-render",
-      "target": "client/components",
-      "weight": 64
-    },
-    {
-      "source": "server/lib",
-      "target": "lib",
-      "weight": 61
-    },
-    {
-      "source": "server/route-modules",
-      "target": "shared/lib",
-      "weight": 58
-    },
-    {
-      "source": "build",
-      "target": "build/webpack",
-      "weight": 50
-    },
-    {
-      "source": "server/lib",
-      "target": "server",
-      "weight": 47
-    },
-    {
-      "source": "build",
-      "target": "server",
-      "weight": 46
-    },
-    {
-      "source": "server/dev",
-      "target": "lib",
-      "weight": 46
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/lib",
-      "weight": 43
-    },
-    {
-      "source": "build/templates",
-      "target": "server/lib",
-      "weight": 42
-    },
-    {
-      "source": "cli",
-      "target": "lib",
-      "weight": 40
-    },
-    {
-      "source": "client/components",
-      "target": "client",
-      "weight": 40
-    },
-    {
-      "source": "server/dev",
-      "target": "server",
-      "weight": 39
-    },
-    {
-      "source": "server/app-render",
-      "target": "server",
-      "weight": 34
-    },
-    {
-      "source": "server/dev",
-      "target": "server/lib",
-      "weight": 34
-    },
-    {
-      "source": "server/dev",
-      "target": "build",
-      "weight": 34
-    },
-    {
-      "source": "server/dev",
-      "target": "next-devtools/server",
-      "weight": 34
-    },
-    {
-      "source": "server/use-cache",
-      "target": "server/app-render",
-      "weight": 34
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server",
-      "weight": 33
-    },
-    {
-      "source": "cli",
-      "target": "server/lib",
-      "weight": 32
-    },
-    {
-      "source": "next-devtools",
-      "target": "next-devtools/dev-overlay",
-      "weight": 32
-    },
-    {
-      "source": "build/webpack",
-      "target": "build",
-      "weight": 31
-    },
-    {
-      "source": "server/request",
-      "target": "server",
-      "weight": 31
-    },
-    {
-      "source": "build/templates",
-      "target": "server/web",
-      "weight": 30
-    },
-    {
-      "source": "export",
-      "target": "shared/lib",
-      "weight": 28
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "next-devtools/shared",
-      "weight": 28
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/stream-utils",
-      "weight": 28
-    },
-    {
-      "source": "build/templates",
-      "target": "server",
-      "weight": 27
-    },
-    {
-      "source": "server/dev",
-      "target": "build/swc",
-      "weight": 26
-    },
-    {
-      "source": "server/lib",
-      "target": "build",
-      "weight": 26
-    },
-    {
-      "source": "build/static-paths",
-      "target": "shared/lib",
-      "weight": 25
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "server/app-render",
-      "weight": 25
-    },
-    {
-      "source": "build",
-      "target": "server/lib",
-      "weight": 24
-    },
-    {
-      "source": "server/lib",
-      "target": "server/response-cache",
-      "weight": 24
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/app-render",
-      "weight": 23
-    },
-    {
-      "source": "shared/lib",
-      "target": "lib",
-      "weight": 23
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/lib",
-      "weight": 22
-    },
-    {
-      "source": "server/route-modules",
-      "target": "client/components",
-      "weight": 22
-    },
-    {
-      "source": "client/dev",
-      "target": "server/dev",
-      "weight": 20
-    },
-    {
-      "source": "export",
-      "target": "server",
-      "weight": 20
-    },
-    {
-      "source": "pages",
-      "target": "shared/lib",
-      "weight": 20
-    },
-    {
-      "source": "server/app-render",
-      "target": "lib",
-      "weight": 20
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/request",
-      "weight": 20
-    },
-    {
-      "source": "server/web",
-      "target": "server/app-render",
-      "weight": 19
-    },
-    {
-      "source": "build/webpack",
-      "target": "server",
-      "weight": 18
-    },
-    {
-      "source": "export",
-      "target": "lib",
-      "weight": 18
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "server/app-render",
-      "weight": 18
-    },
-    {
-      "source": "server/request",
-      "target": "shared/lib",
-      "weight": 18
-    },
-    {
-      "source": "lib",
-      "target": "shared/lib",
-      "weight": 17
-    },
-    {
-      "source": "lib/typescript",
-      "target": "lib",
-      "weight": 17
-    },
-    {
-      "source": "server/lib",
-      "target": "server/app-render",
-      "weight": 17
-    },
-    {
-      "source": "shared/lib",
-      "target": "client",
-      "weight": 17
-    },
-    {
-      "source": "build",
-      "target": "client/components",
-      "weight": 16
-    },
-    {
-      "source": "client",
-      "target": "client/components",
-      "weight": 16
-    },
-    {
-      "source": "client/components",
-      "target": "server/app-render",
-      "weight": 16
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/web",
-      "weight": 16
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "server",
-      "weight": 16
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "server/route-matchers",
-      "weight": 16
-    },
-    {
-      "source": "server/web",
-      "target": "shared/lib",
-      "weight": 16
-    },
-    {
-      "source": "server/web",
-      "target": "server",
-      "weight": 16
-    },
-    {
-      "source": "export/routes",
-      "target": "lib",
-      "weight": 15
-    },
-    {
-      "source": "lib/metadata",
-      "target": "shared/lib",
-      "weight": 15
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "next-devtools/shared",
-      "weight": 15
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "shared/lib",
-      "weight": 15
-    },
-    {
-      "source": "build/templates",
-      "target": "lib",
-      "weight": 14
-    },
-    {
-      "source": "build/webpack",
-      "target": "build/analysis",
-      "weight": 14
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "next-devtools",
-      "weight": 14
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/resume-data-cache",
-      "weight": 14
-    },
-    {
-      "source": "server",
-      "target": "server/app-render",
-      "weight": 14
-    },
-    {
-      "source": "server/web",
-      "target": "server/lib",
-      "weight": 14
-    },
-    {
-      "source": "build",
-      "target": "trace",
-      "weight": 13
-    },
-    {
-      "source": "build",
-      "target": "build/output",
-      "weight": 13
-    },
-    {
-      "source": "build/swc",
-      "target": "server",
-      "weight": 13
-    },
-    {
-      "source": "build/templates",
-      "target": "shared/lib",
-      "weight": 13
-    },
-    {
-      "source": "client/app-dir",
-      "target": "client/components",
-      "weight": 13
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/web",
-      "weight": 13
-    },
-    {
-      "source": "server",
-      "target": "server/base-http",
-      "weight": 13
-    },
-    {
-      "source": "shared/lib",
-      "target": "build/swc",
-      "weight": 13
-    },
-    {
-      "source": "build/adapter",
-      "target": "lib",
-      "weight": 12
-    },
-    {
-      "source": "build",
-      "target": "telemetry/events",
-      "weight": 12
-    },
-    {
-      "source": "build/analysis",
-      "target": "lib",
-      "weight": 12
-    },
-    {
-      "source": "build",
-      "target": "build/swc",
-      "weight": 12
-    },
-    {
-      "source": "build/templates",
-      "target": "server/route-modules",
-      "weight": 12
-    },
-    {
-      "source": "build/webpack",
-      "target": "build/swc",
-      "weight": 12
-    },
-    {
-      "source": "client/dev",
-      "target": "shared/lib",
-      "weight": 12
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "shared/lib",
-      "weight": 12
-    },
-    {
-      "source": "server",
-      "target": "server/response-cache",
-      "weight": 12
-    },
-    {
-      "source": "server",
-      "target": "build/webpack",
-      "weight": 12
-    },
-    {
-      "source": "server",
-      "target": "client/components",
-      "weight": 12
-    },
-    {
-      "source": "server",
-      "target": "server/web",
-      "weight": 12
-    },
-    {
-      "source": "server",
-      "target": "(root)",
-      "weight": 12
-    },
-    {
-      "source": "server/dev",
-      "target": "server/mcp",
-      "weight": 12
-    },
-    {
-      "source": "server",
-      "target": "server/node-environment-extensions",
-      "weight": 12
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/web",
-      "weight": 12
-    },
-    {
-      "source": "build/webpack",
-      "target": "lib/metadata",
-      "weight": 11
-    },
-    {
-      "source": "build/webpack",
-      "target": "server/dev",
-      "weight": 11
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "build",
-      "weight": 11
-    },
-    {
-      "source": "client/app-dir",
-      "target": "client",
-      "weight": 11
-    },
-    {
-      "source": "lib",
-      "target": "build/output",
-      "weight": 11
-    },
-    {
-      "source": "server",
-      "target": "server/route-modules",
-      "weight": 11
-    },
-    {
-      "source": "server/dev",
-      "target": "server/app-render",
-      "weight": 11
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "server/normalizers",
-      "weight": 11
-    },
-    {
-      "source": "server/route-modules",
-      "target": "lib",
-      "weight": 11
-    },
-    {
-      "source": "server/use-cache",
-      "target": "server/lib",
-      "weight": 11
-    },
-    {
-      "source": "shared/lib",
-      "target": "server/request",
-      "weight": 11
-    },
-    {
-      "source": "shared/lib",
-      "target": "server",
-      "weight": 11
-    },
-    {
-      "source": "shared/lib",
-      "target": "build/webpack",
-      "weight": 11
-    },
-    {
-      "source": "build/adapter",
-      "target": "shared/lib",
-      "weight": 10
-    },
-    {
-      "source": "build/analysis",
-      "target": "build/segment-config",
-      "weight": 10
-    },
-    {
-      "source": "client",
-      "target": "client/dev",
-      "weight": 10
-    },
-    {
-      "source": "client/legacy",
-      "target": "shared/lib",
-      "weight": 10
-    },
-    {
-      "source": "export/routes",
-      "target": "server",
-      "weight": 10
-    },
-    {
-      "source": "server/app-render",
-      "target": "build/segment-config",
-      "weight": 10
-    },
-    {
-      "source": "server/lib",
-      "target": "trace",
-      "weight": 10
-    },
-    {
-      "source": "server/route-modules",
-      "target": "(root)",
-      "weight": 10
-    },
-    {
-      "source": "api",
-      "target": "shared/lib",
-      "weight": 9
-    },
-    {
-      "source": "build/adapter",
-      "target": "build",
-      "weight": 9
-    },
-    {
-      "source": "build",
-      "target": "build/analysis",
-      "weight": 9
-    },
-    {
-      "source": "build/templates",
-      "target": "client/components",
-      "weight": 9
-    },
-    {
-      "source": "build/templates",
-      "target": "server/response-cache",
-      "weight": 9
-    },
-    {
-      "source": "cli",
-      "target": "lib/helpers",
-      "weight": 9
-    },
-    {
-      "source": "lib",
-      "target": "server",
-      "weight": 9
-    },
-    {
-      "source": "server/after",
-      "target": "server/app-render",
-      "weight": 9
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/base-http",
-      "weight": 9
-    },
-    {
-      "source": "server/normalizers",
-      "target": "shared/lib",
-      "weight": 9
-    },
-    {
-      "source": "server/request",
-      "target": "server/web",
-      "weight": 9
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/response-cache",
-      "weight": 9
-    },
-    {
-      "source": "trace/report",
-      "target": "trace",
-      "weight": 9
-    },
-    {
-      "source": "api",
-      "target": "client",
-      "weight": 8
-    },
-    {
-      "source": "build/segment-config",
-      "target": "server/route-modules",
-      "weight": 8
-    },
-    {
-      "source": "build/templates",
-      "target": "server/base-http",
-      "weight": 8
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "trace",
-      "weight": 8
-    },
-    {
-      "source": "client",
-      "target": "lib",
-      "weight": 8
-    },
-    {
-      "source": "lib",
-      "target": "lib/helpers",
-      "weight": 8
-    },
-    {
-      "source": "lib",
-      "target": "server/lib",
-      "weight": 8
-    },
-    {
-      "source": "lib/metadata",
-      "target": "server/lib",
-      "weight": 8
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "client/components",
-      "weight": 8
-    },
-    {
-      "source": "server/api-utils",
-      "target": "lib",
-      "weight": 8
-    },
-    {
-      "source": "server/dev",
-      "target": "server/route-definitions",
-      "weight": 8
-    },
-    {
-      "source": "server/dev",
-      "target": "build/output",
-      "weight": 8
-    },
-    {
-      "source": "server/dev",
-      "target": "trace",
-      "weight": 8
-    },
-    {
-      "source": "server/lib",
-      "target": "build/output",
-      "weight": 8
-    },
-    {
-      "source": "server/normalizers",
-      "target": "lib",
-      "weight": 8
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "server/route-definitions",
-      "weight": 8
-    },
-    {
-      "source": "server/route-modules",
-      "target": "build",
-      "weight": 8
-    },
-    {
-      "source": "server/web",
-      "target": "lib",
-      "weight": 8
-    },
-    {
-      "source": "build",
-      "target": "lib/metadata",
-      "weight": 7
-    },
-    {
-      "source": "build/segment-config",
-      "target": "shared/lib",
-      "weight": 7
-    },
-    {
-      "source": "build/templates",
-      "target": "server/app-render",
-      "weight": 7
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "trace",
-      "weight": 7
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "lib",
-      "weight": 7
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "shared/lib",
-      "weight": 7
-    },
-    {
-      "source": "export/routes",
-      "target": "server/lib",
-      "weight": 7
-    },
-    {
-      "source": "lib/metadata",
-      "target": "server/request",
-      "weight": 7
-    },
-    {
-      "source": "server/app-render",
-      "target": "build/webpack",
-      "weight": 7
-    },
-    {
-      "source": "server/dev",
-      "target": "server/route-matcher-providers",
-      "weight": 7
-    },
-    {
-      "source": "server/lib",
-      "target": "server/dev",
-      "weight": 7
-    },
-    {
-      "source": "server/lib",
-      "target": "lib/metadata",
-      "weight": 7
-    },
-    {
-      "source": "server/mcp",
-      "target": "server/dev",
-      "weight": 7
-    },
-    {
-      "source": "server/response-cache",
-      "target": "server",
-      "weight": 7
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "lib",
-      "weight": 7
-    },
-    {
-      "source": "server/web",
-      "target": "client/components",
-      "weight": 7
-    },
-    {
-      "source": "server/web",
-      "target": "server/base-http",
-      "weight": 7
-    },
-    {
-      "source": "(root)",
-      "target": "lib/metadata",
-      "weight": 7
-    },
-    {
-      "source": "api",
-      "target": "pages",
-      "weight": 6
-    },
-    {
-      "source": "build/output",
-      "target": "lib",
-      "weight": 6
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server/request",
-      "weight": 6
-    },
-    {
-      "source": "build/swc",
-      "target": "build",
-      "weight": 6
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "build",
-      "weight": 6
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "build/swc",
-      "weight": 6
-    },
-    {
-      "source": "build/webpack",
-      "target": "trace",
-      "weight": 6
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "build/webpack",
-      "weight": 6
-    },
-    {
-      "source": "cli",
-      "target": "build/output",
-      "weight": 6
-    },
-    {
-      "source": "cli",
-      "target": "trace",
-      "weight": 6
-    },
-    {
-      "source": "client/app-dir",
-      "target": "shared/lib",
-      "weight": 6
-    },
-    {
-      "source": "client",
-      "target": "client/react-client-callbacks",
-      "weight": 6
-    },
-    {
-      "source": "client/components",
-      "target": "server/request",
-      "weight": 6
-    },
-    {
-      "source": "client/dev",
-      "target": "next-devtools/userspace",
-      "weight": 6
-    },
-    {
-      "source": "export/routes",
-      "target": "shared/lib",
-      "weight": 6
-    },
-    {
-      "source": "lib/memory",
-      "target": "build/output",
-      "weight": 6
-    },
-    {
-      "source": "server",
-      "target": "server/api-utils",
-      "weight": 6
-    },
-    {
-      "source": "server/dev",
-      "target": "next-devtools/shared",
-      "weight": 6
-    },
-    {
-      "source": "server/dev",
-      "target": "next-devtools/dev-overlay",
-      "weight": 6
-    },
-    {
-      "source": "server/dev",
-      "target": "server/base-http",
-      "weight": 6
-    },
-    {
-      "source": "server/dev",
-      "target": "server/route-modules",
-      "weight": 6
-    },
-    {
-      "source": "server/lib",
-      "target": "server/web",
-      "weight": 6
-    },
-    {
-      "source": "server",
-      "target": "server/stream-utils",
-      "weight": 6
-    },
-    {
-      "source": "server/request",
-      "target": "client/components",
-      "weight": 6
-    },
-    {
-      "source": "server/route-definitions",
-      "target": "server",
-      "weight": 6
-    },
-    {
-      "source": "server/route-matchers",
-      "target": "server/route-definitions",
-      "weight": 6
-    },
-    {
-      "source": "server/route-matches",
-      "target": "server/route-definitions",
-      "weight": 6
-    },
-    {
-      "source": "server/use-cache",
-      "target": "server",
-      "weight": 6
-    },
-    {
-      "source": "server/web",
-      "target": "server/after",
-      "weight": 6
-    },
-    {
-      "source": "api",
-      "target": "client/components",
-      "weight": 5
-    },
-    {
-      "source": "bin",
-      "target": "lib",
-      "weight": 5
-    },
-    {
-      "source": "build/analysis",
-      "target": "shared/lib",
-      "weight": 5
-    },
-    {
-      "source": "build",
-      "target": "server/api-utils",
-      "weight": 5
-    },
-    {
-      "source": "build",
-      "target": "build/static-paths",
-      "weight": 5
-    },
-    {
-      "source": "build",
-      "target": "build/segment-config",
-      "weight": 5
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server/lib",
-      "weight": 5
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server/app-render",
-      "weight": 5
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server/route-modules",
-      "weight": 5
-    },
-    {
-      "source": "build/templates",
-      "target": "server/request",
-      "weight": 5
-    },
-    {
-      "source": "cli",
-      "target": "server",
-      "weight": 5
-    },
-    {
-      "source": "client/components",
-      "target": "lib",
-      "weight": 5
-    },
-    {
-      "source": "client/dev",
-      "target": "client/components",
-      "weight": 5
-    },
-    {
-      "source": "client/request",
-      "target": "shared/lib",
-      "weight": 5
-    },
-    {
-      "source": "experimental/testing",
-      "target": "lib",
-      "weight": 5
-    },
-    {
-      "source": "export",
-      "target": "build",
-      "weight": 5
-    },
-    {
-      "source": "export",
-      "target": "build/turborepo-access-trace",
-      "weight": 5
-    },
-    {
-      "source": "export/routes",
-      "target": "server/route-modules",
-      "weight": 5
-    },
-    {
-      "source": "lib/memory",
-      "target": "lib",
-      "weight": 5
-    },
-    {
-      "source": "lib/metadata",
-      "target": "server/app-render",
-      "weight": 5
-    },
-    {
-      "source": "lib",
-      "target": "lib/typescript",
-      "weight": 5
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "next-devtools/userspace",
-      "weight": 5
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "shared/lib",
-      "weight": 5
-    },
-    {
-      "source": "server/api-utils",
-      "target": "shared/lib",
-      "weight": 5
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/async-storage",
-      "weight": 5
-    },
-    {
-      "source": "server/app-render",
-      "target": "lib/framework",
-      "weight": 5
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/app-render",
-      "weight": 5
-    },
-    {
-      "source": "server",
-      "target": "build",
-      "weight": 5
-    },
-    {
-      "source": "server",
-      "target": "server/route-matches",
-      "weight": 5
-    },
-    {
-      "source": "server",
-      "target": "server/normalizers",
-      "weight": 5
-    },
-    {
-      "source": "server",
-      "target": "build/output",
-      "weight": 5
-    },
-    {
-      "source": "server",
-      "target": "server/route-matcher-providers",
-      "weight": 5
-    },
-    {
-      "source": "server/lib",
-      "target": "client/components",
-      "weight": 5
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "server",
-      "weight": 5
-    },
-    {
-      "source": "server/response-cache",
-      "target": "lib",
-      "weight": 5
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "server/route-definitions",
-      "weight": 5
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "server/route-matchers",
-      "weight": 5
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/route-definitions",
-      "weight": 5
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/api-utils",
-      "weight": 5
-    },
-    {
-      "source": "server/web",
-      "target": "build/webpack",
-      "weight": 5
-    },
-    {
-      "source": "(root)",
-      "target": "shared/lib",
-      "weight": 5
-    },
-    {
-      "source": "build",
-      "target": "telemetry",
-      "weight": 4
-    },
-    {
-      "source": "build/analyze",
-      "target": "build",
-      "weight": 4
-    },
-    {
-      "source": "build/static-paths",
-      "target": "lib",
-      "weight": 4
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "lib",
-      "weight": 4
-    },
-    {
-      "source": "build",
-      "target": "server/route-modules",
-      "weight": 4
-    },
-    {
-      "source": "cli",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "client/request",
-      "target": "server/request",
-      "weight": 4
-    },
-    {
-      "source": "experimental/testing",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "export/helpers",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "export",
-      "target": "export/helpers",
-      "weight": 4
-    },
-    {
-      "source": "export",
-      "target": "server/request",
-      "weight": 4
-    },
-    {
-      "source": "export/routes",
-      "target": "server/base-http",
-      "weight": 4
-    },
-    {
-      "source": "export",
-      "target": "server/lib",
-      "weight": 4
-    },
-    {
-      "source": "export",
-      "target": "export/routes",
-      "weight": 4
-    },
-    {
-      "source": "lib",
-      "target": "build",
-      "weight": 4
-    },
-    {
-      "source": "lib",
-      "target": "client/components",
-      "weight": 4
-    },
-    {
-      "source": "lib/metadata",
-      "target": "lib",
-      "weight": 4
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "server/dev",
-      "weight": 4
-    },
-    {
-      "source": "next-devtools/shared",
-      "target": "next-devtools/server",
-      "weight": 4
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "lib",
-      "weight": 4
-    },
-    {
-      "source": "server/after",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/api-utils",
-      "target": "server/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/api-utils",
-      "target": "(root)",
-      "weight": 4
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/use-cache",
-      "weight": 4
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/api-utils",
-      "weight": 4
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/base-http",
-      "target": "server/api-utils",
-      "weight": 4
-    },
-    {
-      "source": "server/base-http",
-      "target": "server/web",
-      "weight": 4
-    },
-    {
-      "source": "server",
-      "target": "server/request",
-      "weight": 4
-    },
-    {
-      "source": "server",
-      "target": "server/route-matcher-managers",
-      "weight": 4
-    },
-    {
-      "source": "server",
-      "target": "server/after",
-      "weight": 4
-    },
-    {
-      "source": "server/dev",
-      "target": "build/static-paths",
-      "weight": 4
-    },
-    {
-      "source": "server/lib",
-      "target": "build/webpack",
-      "weight": 4
-    },
-    {
-      "source": "server/mcp",
-      "target": "build/swc",
-      "weight": 4
-    },
-    {
-      "source": "server/mcp",
-      "target": "next-devtools/dev-overlay",
-      "weight": 4
-    },
-    {
-      "source": "server/mcp",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/request",
-      "target": "build/static-paths",
-      "weight": 4
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "lib/metadata",
-      "weight": 4
-    },
-    {
-      "source": "server/route-matchers",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/base-http",
-      "weight": 4
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/normalizers",
-      "weight": 4
-    },
-    {
-      "source": "server/stream-utils",
-      "target": "lib",
-      "weight": 4
-    },
-    {
-      "source": "server/stream-utils",
-      "target": "client/components",
-      "weight": 4
-    },
-    {
-      "source": "server/use-cache",
-      "target": "shared/lib",
-      "weight": 4
-    },
-    {
-      "source": "server/use-cache",
-      "target": "server/request",
-      "weight": 4
-    },
-    {
-      "source": "server/web",
-      "target": "server/response-cache",
-      "weight": 4
-    },
-    {
-      "source": "shared/lib",
-      "target": "build/output",
-      "weight": 4
-    },
-    {
-      "source": "shared/lib",
-      "target": "server/lib",
-      "weight": 4
-    },
-    {
-      "source": "shared/lib",
-      "target": "server/dev",
-      "weight": 4
-    },
-    {
-      "source": "telemetry",
-      "target": "lib",
-      "weight": 4
-    },
-    {
-      "source": "(root)",
-      "target": "client",
-      "weight": 4
-    },
-    {
-      "source": "api",
-      "target": "server/request",
-      "weight": 3
-    },
-    {
-      "source": "bin",
-      "target": "server/lib",
-      "weight": 3
-    },
-    {
-      "source": "build/analysis",
-      "target": "build",
-      "weight": 3
-    },
-    {
-      "source": "build/analyze",
-      "target": "lib",
-      "weight": 3
-    },
-    {
-      "source": "build/babel",
-      "target": "trace",
-      "weight": 3
-    },
-    {
-      "source": "build",
-      "target": "build/turborepo-access-trace",
-      "weight": 3
-    },
-    {
-      "source": "build",
-      "target": "diagnostics",
-      "weight": 3
-    },
-    {
-      "source": "build",
-      "target": "export",
-      "weight": 3
-    },
-    {
-      "source": "build/jest",
-      "target": "build/swc",
-      "weight": 3
-    },
-    {
-      "source": "build/output",
-      "target": "shared/lib",
-      "weight": 3
-    },
-    {
-      "source": "build/output",
-      "target": "trace",
-      "weight": 3
-    },
-    {
-      "source": "build/segment-config",
-      "target": "lib",
-      "weight": 3
-    },
-    {
-      "source": "build/static-paths",
-      "target": "build/segment-config",
-      "weight": 3
-    },
-    {
-      "source": "build/swc",
-      "target": "lib",
-      "weight": 3
-    },
-    {
-      "source": "build/templates",
-      "target": "server/instrumentation",
-      "weight": 3
-    },
-    {
-      "source": "build/templates",
-      "target": "server/api-utils",
-      "weight": 3
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "shared/lib",
-      "weight": 3
-    },
-    {
-      "source": "build/webpack",
-      "target": "server/normalizers",
-      "weight": 3
-    },
-    {
-      "source": "client/react-client-callbacks",
-      "target": "client/components",
-      "weight": 3
-    },
-    {
-      "source": "experimental/testing",
-      "target": "server",
-      "weight": 3
-    },
-    {
-      "source": "experimental/testing",
-      "target": "build",
-      "weight": 3
-    },
-    {
-      "source": "experimental/testing",
-      "target": "server/base-http",
-      "weight": 3
-    },
-    {
-      "source": "export",
-      "target": "build/webpack",
-      "weight": 3
-    },
-    {
-      "source": "export/routes",
-      "target": "export",
-      "weight": 3
-    },
-    {
-      "source": "export/routes",
-      "target": "server/app-render",
-      "weight": 3
-    },
-    {
-      "source": "export/routes",
-      "target": "server/request",
-      "weight": 3
-    },
-    {
-      "source": "export/routes",
-      "target": "server/web",
-      "weight": 3
-    },
-    {
-      "source": "export",
-      "target": "server/route-modules",
-      "weight": 3
-    },
-    {
-      "source": "lib/memory",
-      "target": "trace",
-      "weight": 3
-    },
-    {
-      "source": "lib/metadata",
-      "target": "lib/framework",
-      "weight": 3
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "lib",
-      "weight": 3
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "server/lib",
-      "weight": 3
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "client/lib",
-      "weight": 3
-    },
-    {
-      "source": "server/after",
-      "target": "lib",
-      "weight": 3
-    },
-    {
-      "source": "server/api-utils",
-      "target": "server/web",
-      "weight": 3
-    },
-    {
-      "source": "server/app-render",
-      "target": "(root)",
-      "weight": 3
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/route-modules",
-      "weight": 3
-    },
-    {
-      "source": "server/app-render",
-      "target": "build/output",
-      "weight": 3
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/node-environment-extensions",
-      "weight": 3
-    },
-    {
-      "source": "server/app-render",
-      "target": "lib/metadata",
-      "weight": 3
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/instrumentation",
-      "weight": 3
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/base-http",
-      "weight": 3
-    },
-    {
-      "source": "server/async-storage",
-      "target": "client/components",
-      "weight": 3
-    },
-    {
-      "source": "server/base-http",
-      "target": "server",
-      "weight": 3
-    },
-    {
-      "source": "server/dev",
-      "target": "server/stream-utils",
-      "weight": 3
-    },
-    {
-      "source": "server/dev",
-      "target": "build/webpack",
-      "weight": 3
-    },
-    {
-      "source": "server/dev",
-      "target": "server/route-matcher-managers",
-      "weight": 3
-    },
-    {
-      "source": "server/dev",
-      "target": "server/use-cache",
-      "weight": 3
-    },
-    {
-      "source": "server/lib",
-      "target": "server/base-http",
-      "weight": 3
-    },
-    {
-      "source": "server/lib",
-      "target": "server/normalizers",
-      "weight": 3
-    },
-    {
-      "source": "server",
-      "target": "server/use-cache",
-      "weight": 3
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "shared/lib",
-      "weight": 3
-    },
-    {
-      "source": "server/response-cache",
-      "target": "server/lib",
-      "weight": 3
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "server",
-      "weight": 3
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "server/route-matcher-providers",
-      "weight": 3
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "server/route-matches",
-      "weight": 3
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "server/lib",
-      "weight": 3
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/async-storage",
-      "weight": 3
-    },
-    {
-      "source": "server/route-modules",
-      "target": "pages",
-      "weight": 3
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/instrumentation",
-      "weight": 3
-    },
-    {
-      "source": "shared/lib",
-      "target": "client/components",
-      "weight": 3
-    },
-    {
-      "source": "shared/lib",
-      "target": "(root)",
-      "weight": 3
-    },
-    {
-      "source": "shared/lib",
-      "target": "server/app-render",
-      "weight": 3
-    },
-    {
-      "source": "shared/lib",
-      "target": "trace",
-      "weight": 3
-    },
-    {
-      "source": "telemetry",
-      "target": "server",
-      "weight": 3
-    },
-    {
-      "source": "telemetry/events",
-      "target": "build/webpack",
-      "weight": 3
-    },
-    {
-      "source": "build/adapter",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "build/adapter",
-      "target": "build/webpack",
-      "weight": 2
-    },
-    {
-      "source": "build/adapter",
-      "target": "lib/metadata",
-      "weight": 2
-    },
-    {
-      "source": "build/analysis",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "build/analyze",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "build/analyze",
-      "target": "trace",
-      "weight": 2
-    },
-    {
-      "source": "build/analyze",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "build/analyze",
-      "target": "build/turbopack-analyze",
-      "weight": 2
-    },
-    {
-      "source": "build/babel",
-      "target": "build/swc",
-      "weight": 2
-    },
-    {
-      "source": "build/babel",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "build",
-      "target": "(root)",
-      "weight": 2
-    },
-    {
-      "source": "build/next-config-ts",
-      "target": "build/output",
-      "weight": 2
-    },
-    {
-      "source": "build/output",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "build/segment-config",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "build/templates",
-      "target": "server/stream-utils",
-      "weight": 2
-    },
-    {
-      "source": "build/templates",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "lib",
-      "weight": 2
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "build/swc",
-      "weight": 2
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "telemetry",
-      "weight": 2
-    },
-    {
-      "source": "build/webpack",
-      "target": "client/components",
-      "weight": 2
-    },
-    {
-      "source": "build/webpack",
-      "target": "(root)",
-      "weight": 2
-    },
-    {
-      "source": "build/webpack",
-      "target": "client",
-      "weight": 2
-    },
-    {
-      "source": "build/webpack",
-      "target": "server/web",
-      "weight": 2
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "build/output",
-      "weight": 2
-    },
-    {
-      "source": "build/webpack-config-rules",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "build",
-      "target": "build/webpack-config-rules",
-      "weight": 2
-    },
-    {
-      "source": "cli/internal",
-      "target": "build/swc",
-      "weight": 2
-    },
-    {
-      "source": "cli",
-      "target": "build",
-      "weight": 2
-    },
-    {
-      "source": "cli",
-      "target": "lib/memory",
-      "weight": 2
-    },
-    {
-      "source": "cli",
-      "target": "telemetry",
-      "weight": 2
-    },
-    {
-      "source": "cli",
-      "target": "build/swc",
-      "weight": 2
-    },
-    {
-      "source": "client",
-      "target": "build/polyfills",
-      "weight": 2
-    },
-    {
-      "source": "client/components",
-      "target": "client/lib",
-      "weight": 2
-    },
-    {
-      "source": "client/dev",
-      "target": "client",
-      "weight": 2
-    },
-    {
-      "source": "client/dev",
-      "target": "lib",
-      "weight": 2
-    },
-    {
-      "source": "client/legacy",
-      "target": "client",
-      "weight": 2
-    },
-    {
-      "source": "client",
-      "target": "server/dev",
-      "weight": 2
-    },
-    {
-      "source": "client",
-      "target": "build/analysis",
-      "weight": 2
-    },
-    {
-      "source": "client",
-      "target": "client/lib",
-      "weight": 2
-    },
-    {
-      "source": "client/react-client-callbacks",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "client/request",
-      "target": "server/web",
-      "weight": 2
-    },
-    {
-      "source": "client/tracing",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "diagnostics",
-      "target": "trace",
-      "weight": 2
-    },
-    {
-      "source": "experimental/testing",
-      "target": "server/web",
-      "weight": 2
-    },
-    {
-      "source": "export/helpers",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "export/helpers",
-      "target": "lib",
-      "weight": 2
-    },
-    {
-      "source": "export/helpers",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "export/helpers",
-      "target": "client/components",
-      "weight": 2
-    },
-    {
-      "source": "export",
-      "target": "trace",
-      "weight": 2
-    },
-    {
-      "source": "export/routes",
-      "target": "export/helpers",
-      "weight": 2
-    },
-    {
-      "source": "export/routes",
-      "target": "server/after",
-      "weight": 2
-    },
-    {
-      "source": "export",
-      "target": "server/app-render",
-      "weight": 2
-    },
-    {
-      "source": "export",
-      "target": "server/resume-data-cache",
-      "weight": 2
-    },
-    {
-      "source": "lib",
-      "target": "(root)",
-      "weight": 2
-    },
-    {
-      "source": "lib/metadata",
-      "target": "build/webpack",
-      "weight": 2
-    },
-    {
-      "source": "lib/metadata",
-      "target": "build/output",
-      "weight": 2
-    },
-    {
-      "source": "lib/metadata",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "lib/typescript",
-      "target": "build/output",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools",
-      "target": "next-devtools/shared",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools",
-      "target": "server/dev",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "build/output",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "next-devtools/shared",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "telemetry",
-      "weight": 2
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "client/dev",
-      "weight": 2
-    },
-    {
-      "source": "pages",
-      "target": "client",
-      "weight": 2
-    },
-    {
-      "source": "pages",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "pages",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "server/after",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "server/api-utils",
-      "target": "server/base-http",
-      "weight": 2
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/response-cache",
-      "weight": 2
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/request",
-      "weight": 2
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "server",
-      "target": "build/static-paths",
-      "weight": 2
-    },
-    {
-      "source": "server",
-      "target": "cli",
-      "weight": 2
-    },
-    {
-      "source": "server",
-      "target": "build/swc",
-      "weight": 2
-    },
-    {
-      "source": "server/dev",
-      "target": "server/api-utils",
-      "weight": 2
-    },
-    {
-      "source": "server/dev",
-      "target": "lib/metadata",
-      "weight": 2
-    },
-    {
-      "source": "server/dev",
-      "target": "telemetry",
-      "weight": 2
-    },
-    {
-      "source": "server/dev",
-      "target": "next-devtools/userspace",
-      "weight": 2
-    },
-    {
-      "source": "server/dev",
-      "target": "build/segment-config",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "telemetry",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "server/request",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "(root)",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "server/instrumentation",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "build/swc",
-      "weight": 2
-    },
-    {
-      "source": "server/lib",
-      "target": "telemetry/events",
-      "weight": 2
-    },
-    {
-      "source": "server/mcp",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "server/mcp",
-      "target": "next-devtools/server",
-      "weight": 2
-    },
-    {
-      "source": "server",
-      "target": "next-devtools/userspace",
-      "weight": 2
-    },
-    {
-      "source": "server/request",
-      "target": "server/route-modules",
-      "weight": 2
-    },
-    {
-      "source": "server/resume-data-cache",
-      "target": "server/app-render",
-      "weight": 2
-    },
-    {
-      "source": "server/resume-data-cache",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "lib",
-      "weight": 2
-    },
-    {
-      "source": "server/route-matchers",
-      "target": "server/route-matches",
-      "weight": 2
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/request",
-      "weight": 2
-    },
-    {
-      "source": "server/route-modules",
-      "target": "build/segment-config",
-      "weight": 2
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "server/stream-utils",
-      "target": "server/lib",
-      "weight": 2
-    },
-    {
-      "source": "server/stream-utils",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "server/use-cache",
-      "target": "lib",
-      "weight": 2
-    },
-    {
-      "source": "server/use-cache",
-      "target": "client/components",
-      "weight": 2
-    },
-    {
-      "source": "server/use-cache",
-      "target": "server/web",
-      "weight": 2
-    },
-    {
-      "source": "server/web",
-      "target": "server/async-storage",
-      "weight": 2
-    },
-    {
-      "source": "server/web",
-      "target": "server/route-modules",
-      "weight": 2
-    },
-    {
-      "source": "server/web",
-      "target": "server/use-cache",
-      "weight": 2
-    },
-    {
-      "source": "server/web",
-      "target": "server/instrumentation",
-      "weight": 2
-    },
-    {
-      "source": "server/web",
-      "target": "build/segment-config",
-      "weight": 2
-    },
-    {
-      "source": "shared/lib",
-      "target": "server/api-utils",
-      "weight": 2
-    },
-    {
-      "source": "shared/lib",
-      "target": "next-devtools/dev-overlay",
-      "weight": 2
-    },
-    {
-      "source": "shared/lib",
-      "target": "server/base-http",
-      "weight": 2
-    },
-    {
-      "source": "telemetry/events",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "trace/report",
-      "target": "shared/lib",
-      "weight": 2
-    },
-    {
-      "source": "trace",
-      "target": "lib/helpers",
-      "weight": 2
-    },
-    {
-      "source": "(root)",
-      "target": "server",
-      "weight": 2
-    },
-    {
-      "source": "(root)",
-      "target": "build/adapter",
-      "weight": 2
-    },
-    {
-      "source": "api",
-      "target": "server/og",
-      "weight": 1
-    },
-    {
-      "source": "api",
-      "target": "server/web",
-      "weight": 1
-    },
-    {
-      "source": "bin",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "bin",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/adapter",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/adapter",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "build/analysis",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "build/analysis",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/analysis",
-      "target": "build/webpack",
-      "weight": 1
-    },
-    {
-      "source": "build/analysis",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "build/analyze",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "build/analyze",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/analyze",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "build/analyze",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "build/analyze",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "build/babel",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/babel",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "build/babel",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "build/babel",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "build/webpack-build",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "build/manifests",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "lib/memory",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "server/app-render",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "build/turbopack-build",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "build/adapter",
-      "weight": 1
-    },
-    {
-      "source": "build/jest",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "build/jest",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "build/jest",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "build/jest",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/jest",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "lib/typescript",
-      "weight": 1
-    },
-    {
-      "source": "build/next-config-ts",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "server/normalizers",
-      "weight": 1
-    },
-    {
-      "source": "build/output",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "build/segment-config",
-      "target": "server/request",
-      "weight": 1
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server/after",
-      "weight": 1
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server/async-storage",
-      "weight": 1
-    },
-    {
-      "source": "build/static-paths",
-      "target": "export/helpers",
-      "weight": 1
-    },
-    {
-      "source": "build/static-paths",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "build/static-paths",
-      "target": "(root)",
-      "weight": 1
-    },
-    {
-      "source": "build/swc",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/swc",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "build/swc",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "build/templates",
-      "target": "build/static-paths",
-      "weight": 1
-    },
-    {
-      "source": "build/templates",
-      "target": "build/adapter",
-      "weight": 1
-    },
-    {
-      "source": "build/templates",
-      "target": "(root)",
-      "weight": 1
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "build/turbopack-analyze",
-      "target": "trace",
-      "weight": 1
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "export",
-      "weight": 1
-    },
-    {
-      "source": "build/turbopack-build",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "server/web",
-      "weight": 1
-    },
-    {
-      "source": "build",
-      "target": "export/helpers",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack",
-      "target": "server/route-modules",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack",
-      "target": "server/use-cache",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack",
-      "target": "server/app-render",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "build/webpack-build",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "cli/internal",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "cli/internal",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "cli",
-      "target": "build/analyze",
-      "weight": 1
-    },
-    {
-      "source": "cli",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "cli",
-      "target": "server/dev",
-      "weight": 1
-    },
-    {
-      "source": "cli",
-      "target": "next-devtools/shared",
-      "weight": 1
-    },
-    {
-      "source": "client",
-      "target": "next-devtools/userspace",
-      "weight": 1
-    },
-    {
-      "source": "client/compat",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "client/compat",
-      "target": "client",
-      "weight": 1
-    },
-    {
-      "source": "client/components",
-      "target": "lib/framework",
-      "weight": 1
-    },
-    {
-      "source": "client/components",
-      "target": "client/dev",
-      "weight": 1
-    },
-    {
-      "source": "client/components",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "client/components",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "client/dev",
-      "target": "next-devtools/shared",
-      "weight": 1
-    },
-    {
-      "source": "client/dev",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "client",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "client",
-      "target": "client/portal",
-      "weight": 1
-    },
-    {
-      "source": "client",
-      "target": "client/tracing",
-      "weight": 1
-    },
-    {
-      "source": "client/lib",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "client/lib",
-      "target": "client",
-      "weight": 1
-    },
-    {
-      "source": "client/react-client-callbacks",
-      "target": "next-devtools/userspace",
-      "weight": 1
-    },
-    {
-      "source": "client/react-client-callbacks",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "client",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "client/tracing",
-      "target": "client/dev",
-      "weight": 1
-    },
-    {
-      "source": "diagnostics",
-      "target": "export",
-      "weight": 1
-    },
-    {
-      "source": "diagnostics",
-      "target": "server/base-http",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testing",
-      "target": "server/request",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testing",
-      "target": "server/route-modules",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testing",
-      "target": "build/analysis",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testing",
-      "target": "build/segment-config",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testing",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testmode",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "experimental/testmode",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "export/helpers",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "export/helpers",
-      "target": "server/app-render",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "build/manifests",
-      "weight": 1
-    },
-    {
-      "source": "export/routes",
-      "target": "client/components",
-      "weight": 1
-    },
-    {
-      "source": "export/routes",
-      "target": "server/resume-data-cache",
-      "weight": 1
-    },
-    {
-      "source": "export/routes",
-      "target": "lib/metadata",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "server/base-http",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "client/components",
-      "weight": 1
-    },
-    {
-      "source": "export",
-      "target": "server/node-environment-extensions",
-      "weight": 1
-    },
-    {
-      "source": "lib/helpers",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "lib/helpers",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "lib/metadata",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "lib/metadata",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "lib/metadata",
-      "target": "client/components",
-      "weight": 1
-    },
-    {
-      "source": "lib/typescript",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "lib/typescript",
-      "target": "lib/helpers",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/dev-overlay",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools",
-      "target": "next-devtools/userspace",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "server/dev",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "next-devtools/dev-overlay",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "build/webpack",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/server",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/shared",
-      "target": "next-devtools/dev-overlay",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/shared",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/shared",
-      "target": "server/dev",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "client",
-      "weight": 1
-    },
-    {
-      "source": "next-devtools/userspace",
-      "target": "client/react-client-callbacks",
-      "weight": 1
-    },
-    {
-      "source": "pages",
-      "target": "build/webpack",
-      "weight": 1
-    },
-    {
-      "source": "pages",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "server/after",
-      "target": "server/web",
-      "weight": 1
-    },
-    {
-      "source": "server/api-utils",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "server/api-utils",
-      "target": "server/instrumentation",
-      "weight": 1
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/dev",
-      "weight": 1
-    },
-    {
-      "source": "server/app-render",
-      "target": "build/swc",
-      "weight": 1
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "server/app-render",
-      "target": "next-devtools/dev-overlay",
-      "weight": 1
-    },
-    {
-      "source": "server/app-render",
-      "target": "server/after",
-      "weight": 1
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/response-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/resume-data-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/async-storage",
-      "target": "build/segment-config",
-      "weight": 1
-    },
-    {
-      "source": "server/async-storage",
-      "target": "server/after",
-      "weight": 1
-    },
-    {
-      "source": "server/async-storage",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/base-http",
-      "target": "client/components",
-      "weight": 1
-    },
-    {
-      "source": "server/base-http",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "server/base-http",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "build/analysis",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "server/instrumentation",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "api",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "build/next-config-ts",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "build/adapter",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "server/mcp",
-      "weight": 1
-    },
-    {
-      "source": "server/dev",
-      "target": "server/request",
-      "weight": 1
-    },
-    {
-      "source": "server/dev",
-      "target": "server/response-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/dev",
-      "target": "client",
-      "weight": 1
-    },
-    {
-      "source": "server/dev",
-      "target": "export/helpers",
-      "weight": 1
-    },
-    {
-      "source": "server/dev",
-      "target": "server/after",
-      "weight": 1
-    },
-    {
-      "source": "server/dev",
-      "target": "server/async-storage",
-      "weight": 1
-    },
-    {
-      "source": "server/lib",
-      "target": "export/routes",
-      "weight": 1
-    },
-    {
-      "source": "server/lib",
-      "target": "server/route-modules",
-      "weight": 1
-    },
-    {
-      "source": "server/lib",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "server/lib",
-      "target": "next-devtools/dev-overlay",
-      "weight": 1
-    },
-    {
-      "source": "server/lib",
-      "target": "build/analysis",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "lib/metadata",
-      "weight": 1
-    },
-    {
-      "source": "server/mcp",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "server/mcp",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "server/mcp",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "server/typescript",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "server/dev",
-      "weight": 1
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "server/dev",
-      "weight": 1
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "client/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/node-environment-extensions",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/normalizers",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "next-devtools/server",
-      "weight": 1
-    },
-    {
-      "source": "server",
-      "target": "server/resume-data-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/request",
-      "target": "server/async-storage",
-      "weight": 1
-    },
-    {
-      "source": "server/request",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/response-cache",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "server/resume-data-cache",
-      "target": "server/response-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/resume-data-cache",
-      "target": "server/stream-utils",
-      "weight": 1
-    },
-    {
-      "source": "server/resume-data-cache",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matcher-managers",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matcher-providers",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matchers",
-      "target": "server/lib",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matchers",
-      "target": "server/request",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matches",
-      "target": "server",
-      "weight": 1
-    },
-    {
-      "source": "server/route-matches",
-      "target": "server/request",
-      "weight": 1
-    },
-    {
-      "source": "server/route-modules",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "server/route-modules",
-      "target": "server/resume-data-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/route-modules",
-      "target": "build/adapter",
-      "weight": 1
-    },
-    {
-      "source": "server/route-modules",
-      "target": "build/webpack",
-      "weight": 1
-    },
-    {
-      "source": "server/route-modules",
-      "target": "lib/metadata",
-      "weight": 1
-    },
-    {
-      "source": "server/stream-utils",
-      "target": "server/app-render",
-      "weight": 1
-    },
-    {
-      "source": "server/typescript",
-      "target": "build/segment-config",
-      "weight": 1
-    },
-    {
-      "source": "server/use-cache",
-      "target": "build/webpack",
-      "weight": 1
-    },
-    {
-      "source": "server/use-cache",
-      "target": "server/resume-data-cache",
-      "weight": 1
-    },
-    {
-      "source": "server/use-cache",
-      "target": "build/output",
-      "weight": 1
-    },
-    {
-      "source": "server/web",
-      "target": "server/route-matchers",
-      "weight": 1
-    },
-    {
-      "source": "server/web",
-      "target": "server/request",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "lib/metadata",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "client/lib",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "build/analysis",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "lib/memory",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "telemetry/events",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "lib/fs",
-      "weight": 1
-    },
-    {
-      "source": "shared/lib",
-      "target": "build",
-      "weight": 1
-    },
-    {
-      "source": "telemetry",
-      "target": "shared/lib",
-      "weight": 1
-    },
-    {
-      "source": "telemetry/events",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "telemetry/events",
-      "target": "trace",
-      "weight": 1
-    },
-    {
-      "source": "telemetry/events",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "telemetry",
-      "target": "trace",
-      "weight": 1
-    },
-    {
-      "source": "trace/report",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "trace",
-      "target": "trace/report",
-      "weight": 1
-    },
-    {
-      "source": "trace",
-      "target": "telemetry",
-      "weight": 1
-    },
-    {
-      "source": "(root)",
-      "target": "lib",
-      "weight": 1
-    },
-    {
-      "source": "(root)",
-      "target": "server/api-utils",
-      "weight": 1
-    },
-    {
-      "source": "(root)",
-      "target": "build/segment-config",
-      "weight": 1
-    },
-    {
-      "source": "(root)",
-      "target": "server/instrumentation",
-      "weight": 1
-    }
-  ]
+	"meta": {
+		"source": "vercel/next.js \u00b7 packages/next/src",
+		"parser": "graph-sitter (rust backend)",
+		"parse_seconds": 4.89,
+		"files": 1680,
+		"modules": 91,
+		"edges": 710,
+		"symbols": 16004
+	},
+	"groups": [
+		"(root)",
+		"api",
+		"bin",
+		"build",
+		"bundles",
+		"cli",
+		"client",
+		"diagnostics",
+		"experimental",
+		"export",
+		"lib",
+		"next-devtools",
+		"pages",
+		"server",
+		"shared",
+		"telemetry",
+		"trace"
+	],
+	"nodes": [
+		{
+			"id": "(root)",
+			"group": "(root)",
+			"files": 1,
+			"loc": 327,
+			"symbols": 20,
+			"inbound": 42,
+			"outbound": 24
+		},
+		{
+			"id": "api",
+			"group": "api",
+			"files": 18,
+			"loc": 39,
+			"symbols": 1,
+			"inbound": 1,
+			"outbound": 33
+		},
+		{
+			"id": "bin",
+			"group": "bin",
+			"files": 1,
+			"loc": 763,
+			"symbols": 11,
+			"inbound": 0,
+			"outbound": 10
+		},
+		{
+			"id": "build",
+			"group": "build",
+			"files": 43,
+			"loc": 16061,
+			"symbols": 978,
+			"inbound": 164,
+			"outbound": 491
+		},
+		{
+			"id": "build/adapter",
+			"group": "build",
+			"files": 2,
+			"loc": 2427,
+			"symbols": 60,
+			"inbound": 6,
+			"outbound": 39
+		},
+		{
+			"id": "build/analysis",
+			"group": "build",
+			"files": 4,
+			"loc": 1280,
+			"symbols": 63,
+			"inbound": 29,
+			"outbound": 36
+		},
+		{
+			"id": "build/analyze",
+			"group": "build",
+			"files": 1,
+			"loc": 234,
+			"symbols": 10,
+			"inbound": 1,
+			"outbound": 20
+		},
+		{
+			"id": "build/babel",
+			"group": "build",
+			"files": 14,
+			"loc": 2353,
+			"symbols": 114,
+			"inbound": 1,
+			"outbound": 10
+		},
+		{
+			"id": "build/jest",
+			"group": "build",
+			"files": 6,
+			"loc": 286,
+			"symbols": 26,
+			"inbound": 0,
+			"outbound": 8
+		},
+		{
+			"id": "build/manifests",
+			"group": "build",
+			"files": 1,
+			"loc": 8,
+			"symbols": 1,
+			"inbound": 2,
+			"outbound": 0
+		},
+		{
+			"id": "build/next-config-ts",
+			"group": "build",
+			"files": 2,
+			"loc": 297,
+			"symbols": 16,
+			"inbound": 1,
+			"outbound": 3
+		},
+		{
+			"id": "build/output",
+			"group": "build",
+			"files": 4,
+			"loc": 566,
+			"symbols": 45,
+			"inbound": 87,
+			"outbound": 15
+		},
+		{
+			"id": "build/polyfills",
+			"group": "build",
+			"files": 10,
+			"loc": 36,
+			"symbols": 4,
+			"inbound": 2,
+			"outbound": 0
+		},
+		{
+			"id": "build/segment-config",
+			"group": "build",
+			"files": 5,
+			"loc": 805,
+			"symbols": 41,
+			"inbound": 38,
+			"outbound": 21
+		},
+		{
+			"id": "build/static-paths",
+			"group": "build",
+			"files": 8,
+			"loc": 5709,
+			"symbols": 62,
+			"inbound": 16,
+			"outbound": 58
+		},
+		{
+			"id": "build/swc",
+			"group": "build",
+			"files": 9,
+			"loc": 3974,
+			"symbols": 239,
+			"inbound": 95,
+			"outbound": 25
+		},
+		{
+			"id": "build/templates",
+			"group": "build",
+			"files": 11,
+			"loc": 4190,
+			"symbols": 188,
+			"inbound": 0,
+			"outbound": 189
+		},
+		{
+			"id": "build/turbopack-analyze",
+			"group": "build",
+			"files": 1,
+			"loc": 130,
+			"symbols": 4,
+			"inbound": 2,
+			"outbound": 11
+		},
+		{
+			"id": "build/turbopack-build",
+			"group": "build",
+			"files": 2,
+			"loc": 467,
+			"symbols": 8,
+			"inbound": 1,
+			"outbound": 33
+		},
+		{
+			"id": "build/turborepo-access-trace",
+			"group": "build",
+			"files": 6,
+			"loc": 289,
+			"symbols": 14,
+			"inbound": 8,
+			"outbound": 0
+		},
+		{
+			"id": "build/webpack",
+			"group": "build",
+			"files": 140,
+			"loc": 21358,
+			"symbols": 1965,
+			"inbound": 113,
+			"outbound": 285
+		},
+		{
+			"id": "build/webpack-build",
+			"group": "build",
+			"files": 2,
+			"loc": 623,
+			"symbols": 33,
+			"inbound": 1,
+			"outbound": 45
+		},
+		{
+			"id": "build/webpack-config-rules",
+			"group": "build",
+			"files": 1,
+			"loc": 30,
+			"symbols": 3,
+			"inbound": 2,
+			"outbound": 2
+		},
+		{
+			"id": "bundles",
+			"group": "bundles",
+			"files": 1,
+			"loc": 7,
+			"symbols": 1,
+			"inbound": 0,
+			"outbound": 0
+		},
+		{
+			"id": "bundles/babel",
+			"group": "bundles",
+			"files": 29,
+			"loc": 255,
+			"symbols": 44,
+			"inbound": 0,
+			"outbound": 0
+		},
+		{
+			"id": "bundles/cssnano-simple",
+			"group": "bundles",
+			"files": 3,
+			"loc": 203,
+			"symbols": 7,
+			"inbound": 0,
+			"outbound": 0
+		},
+		{
+			"id": "bundles/postcss-plugin-stub",
+			"group": "bundles",
+			"files": 1,
+			"loc": 25,
+			"symbols": 1,
+			"inbound": 0,
+			"outbound": 0
+		},
+		{
+			"id": "bundles/webpack",
+			"group": "bundles",
+			"files": 26,
+			"loc": 1114,
+			"symbols": 40,
+			"inbound": 0,
+			"outbound": 0
+		},
+		{
+			"id": "cli",
+			"group": "cli",
+			"files": 11,
+			"loc": 1981,
+			"symbols": 208,
+			"inbound": 2,
+			"outbound": 114
+		},
+		{
+			"id": "cli/internal",
+			"group": "cli",
+			"files": 4,
+			"loc": 1819,
+			"symbols": 104,
+			"inbound": 0,
+			"outbound": 4
+		},
+		{
+			"id": "client",
+			"group": "client",
+			"files": 53,
+			"loc": 6685,
+			"symbols": 470,
+			"inbound": 92,
+			"outbound": 167
+		},
+		{
+			"id": "client/app-dir",
+			"group": "client",
+			"files": 3,
+			"loc": 1090,
+			"symbols": 25,
+			"inbound": 0,
+			"outbound": 30
+		},
+		{
+			"id": "client/compat",
+			"group": "client",
+			"files": 1,
+			"loc": 17,
+			"symbols": 1,
+			"inbound": 0,
+			"outbound": 2
+		},
+		{
+			"id": "client/components",
+			"group": "client",
+			"files": 103,
+			"loc": 20577,
+			"symbols": 786,
+			"inbound": 215,
+			"outbound": 244
+		},
+		{
+			"id": "client/dev",
+			"group": "client",
+			"files": 15,
+			"loc": 2544,
+			"symbols": 154,
+			"inbound": 14,
+			"outbound": 49
+		},
+		{
+			"id": "client/legacy",
+			"group": "client",
+			"files": 1,
+			"loc": 1202,
+			"symbols": 57,
+			"inbound": 0,
+			"outbound": 12
+		},
+		{
+			"id": "client/lib",
+			"group": "client",
+			"files": 3,
+			"loc": 225,
+			"symbols": 9,
+			"inbound": 9,
+			"outbound": 2
+		},
+		{
+			"id": "client/portal",
+			"group": "client",
+			"files": 1,
+			"loc": 22,
+			"symbols": 5,
+			"inbound": 1,
+			"outbound": 0
+		},
+		{
+			"id": "client/react-client-callbacks",
+			"group": "client",
+			"files": 3,
+			"loc": 170,
+			"symbols": 12,
+			"inbound": 7,
+			"outbound": 7
+		},
+		{
+			"id": "client/request",
+			"group": "client",
+			"files": 7,
+			"loc": 262,
+			"symbols": 27,
+			"inbound": 0,
+			"outbound": 11
+		},
+		{
+			"id": "client/tracing",
+			"group": "client",
+			"files": 2,
+			"loc": 97,
+			"symbols": 6,
+			"inbound": 1,
+			"outbound": 3
+		},
+		{
+			"id": "diagnostics",
+			"group": "diagnostics",
+			"files": 2,
+			"loc": 183,
+			"symbols": 13,
+			"inbound": 3,
+			"outbound": 4
+		},
+		{
+			"id": "experimental/testing",
+			"group": "experimental",
+			"files": 6,
+			"loc": 902,
+			"symbols": 12,
+			"inbound": 0,
+			"outbound": 25
+		},
+		{
+			"id": "experimental/testmode",
+			"group": "experimental",
+			"files": 18,
+			"loc": 1035,
+			"symbols": 95,
+			"inbound": 0,
+			"outbound": 2
+		},
+		{
+			"id": "export",
+			"group": "export",
+			"files": 4,
+			"loc": 1951,
+			"symbols": 80,
+			"inbound": 8,
+			"outbound": 112
+		},
+		{
+			"id": "export/helpers",
+			"group": "export",
+			"files": 3,
+			"loc": 130,
+			"symbols": 4,
+			"inbound": 9,
+			"outbound": 14
+		},
+		{
+			"id": "export/routes",
+			"group": "export",
+			"files": 4,
+			"loc": 626,
+			"symbols": 6,
+			"inbound": 5,
+			"outbound": 66
+		},
+		{
+			"id": "lib",
+			"group": "lib",
+			"files": 79,
+			"loc": 8684,
+			"symbols": 432,
+			"inbound": 694,
+			"outbound": 68
+		},
+		{
+			"id": "lib/framework",
+			"group": "lib",
+			"files": 2,
+			"loc": 56,
+			"symbols": 9,
+			"inbound": 9,
+			"outbound": 0
+		},
+		{
+			"id": "lib/fs",
+			"group": "lib",
+			"files": 2,
+			"loc": 130,
+			"symbols": 3,
+			"inbound": 1,
+			"outbound": 0
+		},
+		{
+			"id": "lib/helpers",
+			"group": "lib",
+			"files": 8,
+			"loc": 413,
+			"symbols": 17,
+			"inbound": 20,
+			"outbound": 2
+		},
+		{
+			"id": "lib/memory",
+			"group": "lib",
+			"files": 4,
+			"loc": 240,
+			"symbols": 19,
+			"inbound": 4,
+			"outbound": 14
+		},
+		{
+			"id": "lib/metadata",
+			"group": "lib",
+			"files": 29,
+			"loc": 8357,
+			"symbols": 303,
+			"inbound": 47,
+			"outbound": 51
+		},
+		{
+			"id": "lib/typescript",
+			"group": "lib",
+			"files": 9,
+			"loc": 1624,
+			"symbols": 53,
+			"inbound": 6,
+			"outbound": 21
+		},
+		{
+			"id": "next-devtools",
+			"group": "next-devtools",
+			"files": 4,
+			"loc": 494,
+			"symbols": 24,
+			"inbound": 14,
+			"outbound": 39
+		},
+		{
+			"id": "next-devtools/dev-overlay",
+			"group": "next-devtools",
+			"files": 158,
+			"loc": 19418,
+			"symbols": 1100,
+			"inbound": 48,
+			"outbound": 93
+		},
+		{
+			"id": "next-devtools/server",
+			"group": "next-devtools",
+			"files": 11,
+			"loc": 1090,
+			"symbols": 65,
+			"inbound": 41,
+			"outbound": 18
+		},
+		{
+			"id": "next-devtools/shared",
+			"group": "next-devtools",
+			"files": 12,
+			"loc": 658,
+			"symbols": 47,
+			"inbound": 55,
+			"outbound": 7
+		},
+		{
+			"id": "next-devtools/userspace",
+			"group": "next-devtools",
+			"files": 17,
+			"loc": 1573,
+			"symbols": 144,
+			"inbound": 18,
+			"outbound": 39
+		},
+		{
+			"id": "pages",
+			"group": "pages",
+			"files": 3,
+			"loc": 1211,
+			"symbols": 120,
+			"inbound": 9,
+			"outbound": 28
+		},
+		{
+			"id": "server",
+			"group": "server",
+			"files": 55,
+			"loc": 20000,
+			"symbols": 994,
+			"inbound": 447,
+			"outbound": 497
+		},
+		{
+			"id": "server/after",
+			"group": "server",
+			"files": 8,
+			"loc": 1176,
+			"symbols": 32,
+			"inbound": 16,
+			"outbound": 19
+		},
+		{
+			"id": "server/api-utils",
+			"group": "server",
+			"files": 6,
+			"loc": 932,
+			"symbols": 37,
+			"inbound": 38,
+			"outbound": 28
+		},
+		{
+			"id": "server/app-render",
+			"group": "server",
+			"files": 88,
+			"loc": 26740,
+			"symbols": 1371,
+			"inbound": 322,
+			"outbound": 437
+		},
+		{
+			"id": "server/async-storage",
+			"group": "server",
+			"files": 4,
+			"loc": 629,
+			"symbols": 22,
+			"inbound": 13,
+			"outbound": 43
+		},
+		{
+			"id": "server/base-http",
+			"group": "server",
+			"files": 5,
+			"loc": 504,
+			"symbols": 23,
+			"inbound": 66,
+			"outbound": 14
+		},
+		{
+			"id": "server/dev",
+			"group": "server",
+			"files": 31,
+			"loc": 12369,
+			"symbols": 782,
+			"inbound": 63,
+			"outbound": 401
+		},
+		{
+			"id": "server/instrumentation",
+			"group": "server",
+			"files": 2,
+			"loc": 42,
+			"symbols": 6,
+			"inbound": 16,
+			"outbound": 0
+		},
+		{
+			"id": "server/lib",
+			"group": "server",
+			"files": 94,
+			"loc": 17745,
+			"symbols": 1208,
+			"inbound": 378,
+			"outbound": 354
+		},
+		{
+			"id": "server/mcp",
+			"group": "server",
+			"files": 17,
+			"loc": 1780,
+			"symbols": 112,
+			"inbound": 13,
+			"outbound": 26
+		},
+		{
+			"id": "server/node-environment-extensions",
+			"group": "server",
+			"files": 17,
+			"loc": 6111,
+			"symbols": 176,
+			"inbound": 16,
+			"outbound": 30
+		},
+		{
+			"id": "server/normalizers",
+			"group": "server",
+			"files": 30,
+			"loc": 745,
+			"symbols": 38,
+			"inbound": 27,
+			"outbound": 18
+		},
+		{
+			"id": "server/og",
+			"group": "server",
+			"files": 1,
+			"loc": 64,
+			"symbols": 12,
+			"inbound": 1,
+			"outbound": 0
+		},
+		{
+			"id": "server/request",
+			"group": "server",
+			"files": 12,
+			"loc": 4140,
+			"symbols": 132,
+			"inbound": 89,
+			"outbound": 172
+		},
+		{
+			"id": "server/response-cache",
+			"group": "server",
+			"files": 5,
+			"loc": 1142,
+			"symbols": 78,
+			"inbound": 63,
+			"outbound": 16
+		},
+		{
+			"id": "server/resume-data-cache",
+			"group": "server",
+			"files": 3,
+			"loc": 654,
+			"symbols": 22,
+			"inbound": 21,
+			"outbound": 7
+		},
+		{
+			"id": "server/route-definitions",
+			"group": "server",
+			"files": 6,
+			"loc": 66,
+			"symbols": 7,
+			"inbound": 38,
+			"outbound": 6
+		},
+		{
+			"id": "server/route-matcher-managers",
+			"group": "server",
+			"files": 4,
+			"loc": 796,
+			"symbols": 33,
+			"inbound": 7,
+			"outbound": 27
+		},
+		{
+			"id": "server/route-matcher-providers",
+			"group": "server",
+			"files": 27,
+			"loc": 1863,
+			"symbols": 98,
+			"inbound": 15,
+			"outbound": 81
+		},
+		{
+			"id": "server/route-matchers",
+			"group": "server",
+			"files": 6,
+			"loc": 177,
+			"symbols": 13,
+			"inbound": 22,
+			"outbound": 14
+		},
+		{
+			"id": "server/route-matches",
+			"group": "server",
+			"files": 6,
+			"loc": 56,
+			"symbols": 7,
+			"inbound": 10,
+			"outbound": 8
+		},
+		{
+			"id": "server/route-modules",
+			"group": "server",
+			"files": 64,
+			"loc": 4996,
+			"symbols": 371,
+			"inbound": 64,
+			"outbound": 246
+		},
+		{
+			"id": "server/stream-utils",
+			"group": "server",
+			"files": 4,
+			"loc": 1471,
+			"symbols": 141,
+			"inbound": 40,
+			"outbound": 13
+		},
+		{
+			"id": "server/typescript",
+			"group": "server",
+			"files": 10,
+			"loc": 2140,
+			"symbols": 240,
+			"inbound": 1,
+			"outbound": 1
+		},
+		{
+			"id": "server/use-cache",
+			"group": "server",
+			"files": 10,
+			"loc": 4423,
+			"symbols": 142,
+			"inbound": 27,
+			"outbound": 68
+		},
+		{
+			"id": "server/web",
+			"group": "server",
+			"files": 36,
+			"loc": 4955,
+			"symbols": 283,
+			"inbound": 119,
+			"outbound": 114
+		},
+		{
+			"id": "shared/lib",
+			"group": "shared",
+			"files": 164,
+			"loc": 17875,
+			"symbols": 1037,
+			"inbound": 1393,
+			"outbound": 123
+		},
+		{
+			"id": "telemetry",
+			"group": "telemetry",
+			"files": 8,
+			"loc": 714,
+			"symbols": 40,
+			"inbound": 22,
+			"outbound": 9
+		},
+		{
+			"id": "telemetry/events",
+			"group": "telemetry",
+			"files": 10,
+			"loc": 889,
+			"symbols": 57,
+			"inbound": 22,
+			"outbound": 8
+		},
+		{
+			"id": "trace",
+			"group": "trace",
+			"files": 7,
+			"loc": 769,
+			"symbols": 56,
+			"inbound": 88,
+			"outbound": 4
+		},
+		{
+			"id": "trace/report",
+			"group": "trace",
+			"files": 6,
+			"loc": 325,
+			"symbols": 25,
+			"inbound": 1,
+			"outbound": 12
+		}
+	],
+	"edges": [
+		{
+			"source": "server",
+			"target": "shared/lib",
+			"weight": 175
+		},
+		{
+			"source": "client/components",
+			"target": "shared/lib",
+			"weight": 171
+		},
+		{
+			"source": "server/app-render",
+			"target": "shared/lib",
+			"weight": 133
+		},
+		{
+			"source": "build",
+			"target": "lib",
+			"weight": 128
+		},
+		{
+			"source": "build",
+			"target": "shared/lib",
+			"weight": 114
+		},
+		{
+			"source": "client",
+			"target": "shared/lib",
+			"weight": 114
+		},
+		{
+			"source": "server/lib",
+			"target": "shared/lib",
+			"weight": 107
+		},
+		{
+			"source": "server/request",
+			"target": "server/app-render",
+			"weight": 100
+		},
+		{
+			"source": "build/webpack",
+			"target": "shared/lib",
+			"weight": 94
+		},
+		{
+			"source": "server/dev",
+			"target": "shared/lib",
+			"weight": 78
+		},
+		{
+			"source": "server",
+			"target": "server/lib",
+			"weight": 72
+		},
+		{
+			"source": "build/webpack",
+			"target": "lib",
+			"weight": 71
+		},
+		{
+			"source": "server",
+			"target": "lib",
+			"weight": 68
+		},
+		{
+			"source": "server/app-render",
+			"target": "client/components",
+			"weight": 64
+		},
+		{
+			"source": "server/lib",
+			"target": "lib",
+			"weight": 61
+		},
+		{
+			"source": "server/route-modules",
+			"target": "shared/lib",
+			"weight": 58
+		},
+		{
+			"source": "build",
+			"target": "build/webpack",
+			"weight": 50
+		},
+		{
+			"source": "server/lib",
+			"target": "server",
+			"weight": 47
+		},
+		{
+			"source": "build",
+			"target": "server",
+			"weight": 46
+		},
+		{
+			"source": "server/dev",
+			"target": "lib",
+			"weight": 46
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/lib",
+			"weight": 43
+		},
+		{
+			"source": "build/templates",
+			"target": "server/lib",
+			"weight": 42
+		},
+		{
+			"source": "cli",
+			"target": "lib",
+			"weight": 40
+		},
+		{
+			"source": "client/components",
+			"target": "client",
+			"weight": 40
+		},
+		{
+			"source": "server/dev",
+			"target": "server",
+			"weight": 39
+		},
+		{
+			"source": "server/app-render",
+			"target": "server",
+			"weight": 34
+		},
+		{
+			"source": "server/dev",
+			"target": "server/lib",
+			"weight": 34
+		},
+		{
+			"source": "server/dev",
+			"target": "build",
+			"weight": 34
+		},
+		{
+			"source": "server/dev",
+			"target": "next-devtools/server",
+			"weight": 34
+		},
+		{
+			"source": "server/use-cache",
+			"target": "server/app-render",
+			"weight": 34
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server",
+			"weight": 33
+		},
+		{
+			"source": "cli",
+			"target": "server/lib",
+			"weight": 32
+		},
+		{
+			"source": "next-devtools",
+			"target": "next-devtools/dev-overlay",
+			"weight": 32
+		},
+		{
+			"source": "build/webpack",
+			"target": "build",
+			"weight": 31
+		},
+		{
+			"source": "server/request",
+			"target": "server",
+			"weight": 31
+		},
+		{
+			"source": "build/templates",
+			"target": "server/web",
+			"weight": 30
+		},
+		{
+			"source": "export",
+			"target": "shared/lib",
+			"weight": 28
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "next-devtools/shared",
+			"weight": 28
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/stream-utils",
+			"weight": 28
+		},
+		{
+			"source": "build/templates",
+			"target": "server",
+			"weight": 27
+		},
+		{
+			"source": "server/dev",
+			"target": "build/swc",
+			"weight": 26
+		},
+		{
+			"source": "server/lib",
+			"target": "build",
+			"weight": 26
+		},
+		{
+			"source": "build/static-paths",
+			"target": "shared/lib",
+			"weight": 25
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "server/app-render",
+			"weight": 25
+		},
+		{
+			"source": "build",
+			"target": "server/lib",
+			"weight": 24
+		},
+		{
+			"source": "server/lib",
+			"target": "server/response-cache",
+			"weight": 24
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/app-render",
+			"weight": 23
+		},
+		{
+			"source": "shared/lib",
+			"target": "lib",
+			"weight": 23
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/lib",
+			"weight": 22
+		},
+		{
+			"source": "server/route-modules",
+			"target": "client/components",
+			"weight": 22
+		},
+		{
+			"source": "client/dev",
+			"target": "server/dev",
+			"weight": 20
+		},
+		{
+			"source": "export",
+			"target": "server",
+			"weight": 20
+		},
+		{
+			"source": "pages",
+			"target": "shared/lib",
+			"weight": 20
+		},
+		{
+			"source": "server/app-render",
+			"target": "lib",
+			"weight": 20
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/request",
+			"weight": 20
+		},
+		{
+			"source": "server/web",
+			"target": "server/app-render",
+			"weight": 19
+		},
+		{
+			"source": "build/webpack",
+			"target": "server",
+			"weight": 18
+		},
+		{
+			"source": "export",
+			"target": "lib",
+			"weight": 18
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "server/app-render",
+			"weight": 18
+		},
+		{
+			"source": "server/request",
+			"target": "shared/lib",
+			"weight": 18
+		},
+		{
+			"source": "lib",
+			"target": "shared/lib",
+			"weight": 17
+		},
+		{
+			"source": "lib/typescript",
+			"target": "lib",
+			"weight": 17
+		},
+		{
+			"source": "server/lib",
+			"target": "server/app-render",
+			"weight": 17
+		},
+		{
+			"source": "shared/lib",
+			"target": "client",
+			"weight": 17
+		},
+		{
+			"source": "build",
+			"target": "client/components",
+			"weight": 16
+		},
+		{
+			"source": "client",
+			"target": "client/components",
+			"weight": 16
+		},
+		{
+			"source": "client/components",
+			"target": "server/app-render",
+			"weight": 16
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/web",
+			"weight": 16
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "server",
+			"weight": 16
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "server/route-matchers",
+			"weight": 16
+		},
+		{
+			"source": "server/web",
+			"target": "shared/lib",
+			"weight": 16
+		},
+		{
+			"source": "server/web",
+			"target": "server",
+			"weight": 16
+		},
+		{
+			"source": "export/routes",
+			"target": "lib",
+			"weight": 15
+		},
+		{
+			"source": "lib/metadata",
+			"target": "shared/lib",
+			"weight": 15
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "next-devtools/shared",
+			"weight": 15
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "shared/lib",
+			"weight": 15
+		},
+		{
+			"source": "build/templates",
+			"target": "lib",
+			"weight": 14
+		},
+		{
+			"source": "build/webpack",
+			"target": "build/analysis",
+			"weight": 14
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "next-devtools",
+			"weight": 14
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/resume-data-cache",
+			"weight": 14
+		},
+		{
+			"source": "server",
+			"target": "server/app-render",
+			"weight": 14
+		},
+		{
+			"source": "server/web",
+			"target": "server/lib",
+			"weight": 14
+		},
+		{
+			"source": "build",
+			"target": "trace",
+			"weight": 13
+		},
+		{
+			"source": "build",
+			"target": "build/output",
+			"weight": 13
+		},
+		{
+			"source": "build/swc",
+			"target": "server",
+			"weight": 13
+		},
+		{
+			"source": "build/templates",
+			"target": "shared/lib",
+			"weight": 13
+		},
+		{
+			"source": "client/app-dir",
+			"target": "client/components",
+			"weight": 13
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/web",
+			"weight": 13
+		},
+		{
+			"source": "server",
+			"target": "server/base-http",
+			"weight": 13
+		},
+		{
+			"source": "shared/lib",
+			"target": "build/swc",
+			"weight": 13
+		},
+		{
+			"source": "build/adapter",
+			"target": "lib",
+			"weight": 12
+		},
+		{
+			"source": "build",
+			"target": "telemetry/events",
+			"weight": 12
+		},
+		{
+			"source": "build/analysis",
+			"target": "lib",
+			"weight": 12
+		},
+		{
+			"source": "build",
+			"target": "build/swc",
+			"weight": 12
+		},
+		{
+			"source": "build/templates",
+			"target": "server/route-modules",
+			"weight": 12
+		},
+		{
+			"source": "build/webpack",
+			"target": "build/swc",
+			"weight": 12
+		},
+		{
+			"source": "client/dev",
+			"target": "shared/lib",
+			"weight": 12
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "shared/lib",
+			"weight": 12
+		},
+		{
+			"source": "server",
+			"target": "server/response-cache",
+			"weight": 12
+		},
+		{
+			"source": "server",
+			"target": "build/webpack",
+			"weight": 12
+		},
+		{
+			"source": "server",
+			"target": "client/components",
+			"weight": 12
+		},
+		{
+			"source": "server",
+			"target": "server/web",
+			"weight": 12
+		},
+		{
+			"source": "server",
+			"target": "(root)",
+			"weight": 12
+		},
+		{
+			"source": "server/dev",
+			"target": "server/mcp",
+			"weight": 12
+		},
+		{
+			"source": "server",
+			"target": "server/node-environment-extensions",
+			"weight": 12
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/web",
+			"weight": 12
+		},
+		{
+			"source": "build/webpack",
+			"target": "lib/metadata",
+			"weight": 11
+		},
+		{
+			"source": "build/webpack",
+			"target": "server/dev",
+			"weight": 11
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "build",
+			"weight": 11
+		},
+		{
+			"source": "client/app-dir",
+			"target": "client",
+			"weight": 11
+		},
+		{
+			"source": "lib",
+			"target": "build/output",
+			"weight": 11
+		},
+		{
+			"source": "server",
+			"target": "server/route-modules",
+			"weight": 11
+		},
+		{
+			"source": "server/dev",
+			"target": "server/app-render",
+			"weight": 11
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "server/normalizers",
+			"weight": 11
+		},
+		{
+			"source": "server/route-modules",
+			"target": "lib",
+			"weight": 11
+		},
+		{
+			"source": "server/use-cache",
+			"target": "server/lib",
+			"weight": 11
+		},
+		{
+			"source": "shared/lib",
+			"target": "server/request",
+			"weight": 11
+		},
+		{
+			"source": "shared/lib",
+			"target": "server",
+			"weight": 11
+		},
+		{
+			"source": "shared/lib",
+			"target": "build/webpack",
+			"weight": 11
+		},
+		{
+			"source": "build/adapter",
+			"target": "shared/lib",
+			"weight": 10
+		},
+		{
+			"source": "build/analysis",
+			"target": "build/segment-config",
+			"weight": 10
+		},
+		{
+			"source": "client",
+			"target": "client/dev",
+			"weight": 10
+		},
+		{
+			"source": "client/legacy",
+			"target": "shared/lib",
+			"weight": 10
+		},
+		{
+			"source": "export/routes",
+			"target": "server",
+			"weight": 10
+		},
+		{
+			"source": "server/app-render",
+			"target": "build/segment-config",
+			"weight": 10
+		},
+		{
+			"source": "server/lib",
+			"target": "trace",
+			"weight": 10
+		},
+		{
+			"source": "server/route-modules",
+			"target": "(root)",
+			"weight": 10
+		},
+		{
+			"source": "api",
+			"target": "shared/lib",
+			"weight": 9
+		},
+		{
+			"source": "build/adapter",
+			"target": "build",
+			"weight": 9
+		},
+		{
+			"source": "build",
+			"target": "build/analysis",
+			"weight": 9
+		},
+		{
+			"source": "build/templates",
+			"target": "client/components",
+			"weight": 9
+		},
+		{
+			"source": "build/templates",
+			"target": "server/response-cache",
+			"weight": 9
+		},
+		{
+			"source": "cli",
+			"target": "lib/helpers",
+			"weight": 9
+		},
+		{
+			"source": "lib",
+			"target": "server",
+			"weight": 9
+		},
+		{
+			"source": "server/after",
+			"target": "server/app-render",
+			"weight": 9
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/base-http",
+			"weight": 9
+		},
+		{
+			"source": "server/normalizers",
+			"target": "shared/lib",
+			"weight": 9
+		},
+		{
+			"source": "server/request",
+			"target": "server/web",
+			"weight": 9
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/response-cache",
+			"weight": 9
+		},
+		{
+			"source": "trace/report",
+			"target": "trace",
+			"weight": 9
+		},
+		{
+			"source": "api",
+			"target": "client",
+			"weight": 8
+		},
+		{
+			"source": "build/segment-config",
+			"target": "server/route-modules",
+			"weight": 8
+		},
+		{
+			"source": "build/templates",
+			"target": "server/base-http",
+			"weight": 8
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "trace",
+			"weight": 8
+		},
+		{
+			"source": "client",
+			"target": "lib",
+			"weight": 8
+		},
+		{
+			"source": "lib",
+			"target": "lib/helpers",
+			"weight": 8
+		},
+		{
+			"source": "lib",
+			"target": "server/lib",
+			"weight": 8
+		},
+		{
+			"source": "lib/metadata",
+			"target": "server/lib",
+			"weight": 8
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "client/components",
+			"weight": 8
+		},
+		{
+			"source": "server/api-utils",
+			"target": "lib",
+			"weight": 8
+		},
+		{
+			"source": "server/dev",
+			"target": "server/route-definitions",
+			"weight": 8
+		},
+		{
+			"source": "server/dev",
+			"target": "build/output",
+			"weight": 8
+		},
+		{
+			"source": "server/dev",
+			"target": "trace",
+			"weight": 8
+		},
+		{
+			"source": "server/lib",
+			"target": "build/output",
+			"weight": 8
+		},
+		{
+			"source": "server/normalizers",
+			"target": "lib",
+			"weight": 8
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "server/route-definitions",
+			"weight": 8
+		},
+		{
+			"source": "server/route-modules",
+			"target": "build",
+			"weight": 8
+		},
+		{
+			"source": "server/web",
+			"target": "lib",
+			"weight": 8
+		},
+		{
+			"source": "build",
+			"target": "lib/metadata",
+			"weight": 7
+		},
+		{
+			"source": "build/segment-config",
+			"target": "shared/lib",
+			"weight": 7
+		},
+		{
+			"source": "build/templates",
+			"target": "server/app-render",
+			"weight": 7
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "trace",
+			"weight": 7
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "lib",
+			"weight": 7
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "shared/lib",
+			"weight": 7
+		},
+		{
+			"source": "export/routes",
+			"target": "server/lib",
+			"weight": 7
+		},
+		{
+			"source": "lib/metadata",
+			"target": "server/request",
+			"weight": 7
+		},
+		{
+			"source": "server/app-render",
+			"target": "build/webpack",
+			"weight": 7
+		},
+		{
+			"source": "server/dev",
+			"target": "server/route-matcher-providers",
+			"weight": 7
+		},
+		{
+			"source": "server/lib",
+			"target": "server/dev",
+			"weight": 7
+		},
+		{
+			"source": "server/lib",
+			"target": "lib/metadata",
+			"weight": 7
+		},
+		{
+			"source": "server/mcp",
+			"target": "server/dev",
+			"weight": 7
+		},
+		{
+			"source": "server/response-cache",
+			"target": "server",
+			"weight": 7
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "lib",
+			"weight": 7
+		},
+		{
+			"source": "server/web",
+			"target": "client/components",
+			"weight": 7
+		},
+		{
+			"source": "server/web",
+			"target": "server/base-http",
+			"weight": 7
+		},
+		{
+			"source": "(root)",
+			"target": "lib/metadata",
+			"weight": 7
+		},
+		{
+			"source": "api",
+			"target": "pages",
+			"weight": 6
+		},
+		{
+			"source": "build/output",
+			"target": "lib",
+			"weight": 6
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server/request",
+			"weight": 6
+		},
+		{
+			"source": "build/swc",
+			"target": "build",
+			"weight": 6
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "build",
+			"weight": 6
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "build/swc",
+			"weight": 6
+		},
+		{
+			"source": "build/webpack",
+			"target": "trace",
+			"weight": 6
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "build/webpack",
+			"weight": 6
+		},
+		{
+			"source": "cli",
+			"target": "build/output",
+			"weight": 6
+		},
+		{
+			"source": "cli",
+			"target": "trace",
+			"weight": 6
+		},
+		{
+			"source": "client/app-dir",
+			"target": "shared/lib",
+			"weight": 6
+		},
+		{
+			"source": "client",
+			"target": "client/react-client-callbacks",
+			"weight": 6
+		},
+		{
+			"source": "client/components",
+			"target": "server/request",
+			"weight": 6
+		},
+		{
+			"source": "client/dev",
+			"target": "next-devtools/userspace",
+			"weight": 6
+		},
+		{
+			"source": "export/routes",
+			"target": "shared/lib",
+			"weight": 6
+		},
+		{
+			"source": "lib/memory",
+			"target": "build/output",
+			"weight": 6
+		},
+		{
+			"source": "server",
+			"target": "server/api-utils",
+			"weight": 6
+		},
+		{
+			"source": "server/dev",
+			"target": "next-devtools/shared",
+			"weight": 6
+		},
+		{
+			"source": "server/dev",
+			"target": "next-devtools/dev-overlay",
+			"weight": 6
+		},
+		{
+			"source": "server/dev",
+			"target": "server/base-http",
+			"weight": 6
+		},
+		{
+			"source": "server/dev",
+			"target": "server/route-modules",
+			"weight": 6
+		},
+		{
+			"source": "server/lib",
+			"target": "server/web",
+			"weight": 6
+		},
+		{
+			"source": "server",
+			"target": "server/stream-utils",
+			"weight": 6
+		},
+		{
+			"source": "server/request",
+			"target": "client/components",
+			"weight": 6
+		},
+		{
+			"source": "server/route-definitions",
+			"target": "server",
+			"weight": 6
+		},
+		{
+			"source": "server/route-matchers",
+			"target": "server/route-definitions",
+			"weight": 6
+		},
+		{
+			"source": "server/route-matches",
+			"target": "server/route-definitions",
+			"weight": 6
+		},
+		{
+			"source": "server/use-cache",
+			"target": "server",
+			"weight": 6
+		},
+		{
+			"source": "server/web",
+			"target": "server/after",
+			"weight": 6
+		},
+		{
+			"source": "api",
+			"target": "client/components",
+			"weight": 5
+		},
+		{
+			"source": "bin",
+			"target": "lib",
+			"weight": 5
+		},
+		{
+			"source": "build/analysis",
+			"target": "shared/lib",
+			"weight": 5
+		},
+		{
+			"source": "build",
+			"target": "server/api-utils",
+			"weight": 5
+		},
+		{
+			"source": "build",
+			"target": "build/static-paths",
+			"weight": 5
+		},
+		{
+			"source": "build",
+			"target": "build/segment-config",
+			"weight": 5
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server/lib",
+			"weight": 5
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server/app-render",
+			"weight": 5
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server/route-modules",
+			"weight": 5
+		},
+		{
+			"source": "build/templates",
+			"target": "server/request",
+			"weight": 5
+		},
+		{
+			"source": "cli",
+			"target": "server",
+			"weight": 5
+		},
+		{
+			"source": "client/components",
+			"target": "lib",
+			"weight": 5
+		},
+		{
+			"source": "client/dev",
+			"target": "client/components",
+			"weight": 5
+		},
+		{
+			"source": "client/request",
+			"target": "shared/lib",
+			"weight": 5
+		},
+		{
+			"source": "experimental/testing",
+			"target": "lib",
+			"weight": 5
+		},
+		{
+			"source": "export",
+			"target": "build",
+			"weight": 5
+		},
+		{
+			"source": "export",
+			"target": "build/turborepo-access-trace",
+			"weight": 5
+		},
+		{
+			"source": "export/routes",
+			"target": "server/route-modules",
+			"weight": 5
+		},
+		{
+			"source": "lib/memory",
+			"target": "lib",
+			"weight": 5
+		},
+		{
+			"source": "lib/metadata",
+			"target": "server/app-render",
+			"weight": 5
+		},
+		{
+			"source": "lib",
+			"target": "lib/typescript",
+			"weight": 5
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "next-devtools/userspace",
+			"weight": 5
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "shared/lib",
+			"weight": 5
+		},
+		{
+			"source": "server/api-utils",
+			"target": "shared/lib",
+			"weight": 5
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/async-storage",
+			"weight": 5
+		},
+		{
+			"source": "server/app-render",
+			"target": "lib/framework",
+			"weight": 5
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/app-render",
+			"weight": 5
+		},
+		{
+			"source": "server",
+			"target": "build",
+			"weight": 5
+		},
+		{
+			"source": "server",
+			"target": "server/route-matches",
+			"weight": 5
+		},
+		{
+			"source": "server",
+			"target": "server/normalizers",
+			"weight": 5
+		},
+		{
+			"source": "server",
+			"target": "build/output",
+			"weight": 5
+		},
+		{
+			"source": "server",
+			"target": "server/route-matcher-providers",
+			"weight": 5
+		},
+		{
+			"source": "server/lib",
+			"target": "client/components",
+			"weight": 5
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "server",
+			"weight": 5
+		},
+		{
+			"source": "server/response-cache",
+			"target": "lib",
+			"weight": 5
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "server/route-definitions",
+			"weight": 5
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "server/route-matchers",
+			"weight": 5
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/route-definitions",
+			"weight": 5
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/api-utils",
+			"weight": 5
+		},
+		{
+			"source": "server/web",
+			"target": "build/webpack",
+			"weight": 5
+		},
+		{
+			"source": "(root)",
+			"target": "shared/lib",
+			"weight": 5
+		},
+		{
+			"source": "build",
+			"target": "telemetry",
+			"weight": 4
+		},
+		{
+			"source": "build/analyze",
+			"target": "build",
+			"weight": 4
+		},
+		{
+			"source": "build/static-paths",
+			"target": "lib",
+			"weight": 4
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "lib",
+			"weight": 4
+		},
+		{
+			"source": "build",
+			"target": "server/route-modules",
+			"weight": 4
+		},
+		{
+			"source": "cli",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "client/request",
+			"target": "server/request",
+			"weight": 4
+		},
+		{
+			"source": "experimental/testing",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "export/helpers",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "export",
+			"target": "export/helpers",
+			"weight": 4
+		},
+		{
+			"source": "export",
+			"target": "server/request",
+			"weight": 4
+		},
+		{
+			"source": "export/routes",
+			"target": "server/base-http",
+			"weight": 4
+		},
+		{
+			"source": "export",
+			"target": "server/lib",
+			"weight": 4
+		},
+		{
+			"source": "export",
+			"target": "export/routes",
+			"weight": 4
+		},
+		{
+			"source": "lib",
+			"target": "build",
+			"weight": 4
+		},
+		{
+			"source": "lib",
+			"target": "client/components",
+			"weight": 4
+		},
+		{
+			"source": "lib/metadata",
+			"target": "lib",
+			"weight": 4
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "server/dev",
+			"weight": 4
+		},
+		{
+			"source": "next-devtools/shared",
+			"target": "next-devtools/server",
+			"weight": 4
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "lib",
+			"weight": 4
+		},
+		{
+			"source": "server/after",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/api-utils",
+			"target": "server/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/api-utils",
+			"target": "(root)",
+			"weight": 4
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/use-cache",
+			"weight": 4
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/api-utils",
+			"weight": 4
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/base-http",
+			"target": "server/api-utils",
+			"weight": 4
+		},
+		{
+			"source": "server/base-http",
+			"target": "server/web",
+			"weight": 4
+		},
+		{
+			"source": "server",
+			"target": "server/request",
+			"weight": 4
+		},
+		{
+			"source": "server",
+			"target": "server/route-matcher-managers",
+			"weight": 4
+		},
+		{
+			"source": "server",
+			"target": "server/after",
+			"weight": 4
+		},
+		{
+			"source": "server/dev",
+			"target": "build/static-paths",
+			"weight": 4
+		},
+		{
+			"source": "server/lib",
+			"target": "build/webpack",
+			"weight": 4
+		},
+		{
+			"source": "server/mcp",
+			"target": "build/swc",
+			"weight": 4
+		},
+		{
+			"source": "server/mcp",
+			"target": "next-devtools/dev-overlay",
+			"weight": 4
+		},
+		{
+			"source": "server/mcp",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/request",
+			"target": "build/static-paths",
+			"weight": 4
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "lib/metadata",
+			"weight": 4
+		},
+		{
+			"source": "server/route-matchers",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/base-http",
+			"weight": 4
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/normalizers",
+			"weight": 4
+		},
+		{
+			"source": "server/stream-utils",
+			"target": "lib",
+			"weight": 4
+		},
+		{
+			"source": "server/stream-utils",
+			"target": "client/components",
+			"weight": 4
+		},
+		{
+			"source": "server/use-cache",
+			"target": "shared/lib",
+			"weight": 4
+		},
+		{
+			"source": "server/use-cache",
+			"target": "server/request",
+			"weight": 4
+		},
+		{
+			"source": "server/web",
+			"target": "server/response-cache",
+			"weight": 4
+		},
+		{
+			"source": "shared/lib",
+			"target": "build/output",
+			"weight": 4
+		},
+		{
+			"source": "shared/lib",
+			"target": "server/lib",
+			"weight": 4
+		},
+		{
+			"source": "shared/lib",
+			"target": "server/dev",
+			"weight": 4
+		},
+		{
+			"source": "telemetry",
+			"target": "lib",
+			"weight": 4
+		},
+		{
+			"source": "(root)",
+			"target": "client",
+			"weight": 4
+		},
+		{
+			"source": "api",
+			"target": "server/request",
+			"weight": 3
+		},
+		{
+			"source": "bin",
+			"target": "server/lib",
+			"weight": 3
+		},
+		{
+			"source": "build/analysis",
+			"target": "build",
+			"weight": 3
+		},
+		{
+			"source": "build/analyze",
+			"target": "lib",
+			"weight": 3
+		},
+		{
+			"source": "build/babel",
+			"target": "trace",
+			"weight": 3
+		},
+		{
+			"source": "build",
+			"target": "build/turborepo-access-trace",
+			"weight": 3
+		},
+		{
+			"source": "build",
+			"target": "diagnostics",
+			"weight": 3
+		},
+		{
+			"source": "build",
+			"target": "export",
+			"weight": 3
+		},
+		{
+			"source": "build/jest",
+			"target": "build/swc",
+			"weight": 3
+		},
+		{
+			"source": "build/output",
+			"target": "shared/lib",
+			"weight": 3
+		},
+		{
+			"source": "build/output",
+			"target": "trace",
+			"weight": 3
+		},
+		{
+			"source": "build/segment-config",
+			"target": "lib",
+			"weight": 3
+		},
+		{
+			"source": "build/static-paths",
+			"target": "build/segment-config",
+			"weight": 3
+		},
+		{
+			"source": "build/swc",
+			"target": "lib",
+			"weight": 3
+		},
+		{
+			"source": "build/templates",
+			"target": "server/instrumentation",
+			"weight": 3
+		},
+		{
+			"source": "build/templates",
+			"target": "server/api-utils",
+			"weight": 3
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "shared/lib",
+			"weight": 3
+		},
+		{
+			"source": "build/webpack",
+			"target": "server/normalizers",
+			"weight": 3
+		},
+		{
+			"source": "client/react-client-callbacks",
+			"target": "client/components",
+			"weight": 3
+		},
+		{
+			"source": "experimental/testing",
+			"target": "server",
+			"weight": 3
+		},
+		{
+			"source": "experimental/testing",
+			"target": "build",
+			"weight": 3
+		},
+		{
+			"source": "experimental/testing",
+			"target": "server/base-http",
+			"weight": 3
+		},
+		{
+			"source": "export",
+			"target": "build/webpack",
+			"weight": 3
+		},
+		{
+			"source": "export/routes",
+			"target": "export",
+			"weight": 3
+		},
+		{
+			"source": "export/routes",
+			"target": "server/app-render",
+			"weight": 3
+		},
+		{
+			"source": "export/routes",
+			"target": "server/request",
+			"weight": 3
+		},
+		{
+			"source": "export/routes",
+			"target": "server/web",
+			"weight": 3
+		},
+		{
+			"source": "export",
+			"target": "server/route-modules",
+			"weight": 3
+		},
+		{
+			"source": "lib/memory",
+			"target": "trace",
+			"weight": 3
+		},
+		{
+			"source": "lib/metadata",
+			"target": "lib/framework",
+			"weight": 3
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "lib",
+			"weight": 3
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "server/lib",
+			"weight": 3
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "client/lib",
+			"weight": 3
+		},
+		{
+			"source": "server/after",
+			"target": "lib",
+			"weight": 3
+		},
+		{
+			"source": "server/api-utils",
+			"target": "server/web",
+			"weight": 3
+		},
+		{
+			"source": "server/app-render",
+			"target": "(root)",
+			"weight": 3
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/route-modules",
+			"weight": 3
+		},
+		{
+			"source": "server/app-render",
+			"target": "build/output",
+			"weight": 3
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/node-environment-extensions",
+			"weight": 3
+		},
+		{
+			"source": "server/app-render",
+			"target": "lib/metadata",
+			"weight": 3
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/instrumentation",
+			"weight": 3
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/base-http",
+			"weight": 3
+		},
+		{
+			"source": "server/async-storage",
+			"target": "client/components",
+			"weight": 3
+		},
+		{
+			"source": "server/base-http",
+			"target": "server",
+			"weight": 3
+		},
+		{
+			"source": "server/dev",
+			"target": "server/stream-utils",
+			"weight": 3
+		},
+		{
+			"source": "server/dev",
+			"target": "build/webpack",
+			"weight": 3
+		},
+		{
+			"source": "server/dev",
+			"target": "server/route-matcher-managers",
+			"weight": 3
+		},
+		{
+			"source": "server/dev",
+			"target": "server/use-cache",
+			"weight": 3
+		},
+		{
+			"source": "server/lib",
+			"target": "server/base-http",
+			"weight": 3
+		},
+		{
+			"source": "server/lib",
+			"target": "server/normalizers",
+			"weight": 3
+		},
+		{
+			"source": "server",
+			"target": "server/use-cache",
+			"weight": 3
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "shared/lib",
+			"weight": 3
+		},
+		{
+			"source": "server/response-cache",
+			"target": "server/lib",
+			"weight": 3
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "server",
+			"weight": 3
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "server/route-matcher-providers",
+			"weight": 3
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "server/route-matches",
+			"weight": 3
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "server/lib",
+			"weight": 3
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/async-storage",
+			"weight": 3
+		},
+		{
+			"source": "server/route-modules",
+			"target": "pages",
+			"weight": 3
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/instrumentation",
+			"weight": 3
+		},
+		{
+			"source": "shared/lib",
+			"target": "client/components",
+			"weight": 3
+		},
+		{
+			"source": "shared/lib",
+			"target": "(root)",
+			"weight": 3
+		},
+		{
+			"source": "shared/lib",
+			"target": "server/app-render",
+			"weight": 3
+		},
+		{
+			"source": "shared/lib",
+			"target": "trace",
+			"weight": 3
+		},
+		{
+			"source": "telemetry",
+			"target": "server",
+			"weight": 3
+		},
+		{
+			"source": "telemetry/events",
+			"target": "build/webpack",
+			"weight": 3
+		},
+		{
+			"source": "build/adapter",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "build/adapter",
+			"target": "build/webpack",
+			"weight": 2
+		},
+		{
+			"source": "build/adapter",
+			"target": "lib/metadata",
+			"weight": 2
+		},
+		{
+			"source": "build/analysis",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "build/analyze",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "build/analyze",
+			"target": "trace",
+			"weight": 2
+		},
+		{
+			"source": "build/analyze",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "build/analyze",
+			"target": "build/turbopack-analyze",
+			"weight": 2
+		},
+		{
+			"source": "build/babel",
+			"target": "build/swc",
+			"weight": 2
+		},
+		{
+			"source": "build/babel",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "build",
+			"target": "(root)",
+			"weight": 2
+		},
+		{
+			"source": "build/next-config-ts",
+			"target": "build/output",
+			"weight": 2
+		},
+		{
+			"source": "build/output",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "build/segment-config",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "build/templates",
+			"target": "server/stream-utils",
+			"weight": 2
+		},
+		{
+			"source": "build/templates",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "lib",
+			"weight": 2
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "build/swc",
+			"weight": 2
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "telemetry",
+			"weight": 2
+		},
+		{
+			"source": "build/webpack",
+			"target": "client/components",
+			"weight": 2
+		},
+		{
+			"source": "build/webpack",
+			"target": "(root)",
+			"weight": 2
+		},
+		{
+			"source": "build/webpack",
+			"target": "client",
+			"weight": 2
+		},
+		{
+			"source": "build/webpack",
+			"target": "server/web",
+			"weight": 2
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "build/output",
+			"weight": 2
+		},
+		{
+			"source": "build/webpack-config-rules",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "build",
+			"target": "build/webpack-config-rules",
+			"weight": 2
+		},
+		{
+			"source": "cli/internal",
+			"target": "build/swc",
+			"weight": 2
+		},
+		{
+			"source": "cli",
+			"target": "build",
+			"weight": 2
+		},
+		{
+			"source": "cli",
+			"target": "lib/memory",
+			"weight": 2
+		},
+		{
+			"source": "cli",
+			"target": "telemetry",
+			"weight": 2
+		},
+		{
+			"source": "cli",
+			"target": "build/swc",
+			"weight": 2
+		},
+		{
+			"source": "client",
+			"target": "build/polyfills",
+			"weight": 2
+		},
+		{
+			"source": "client/components",
+			"target": "client/lib",
+			"weight": 2
+		},
+		{
+			"source": "client/dev",
+			"target": "client",
+			"weight": 2
+		},
+		{
+			"source": "client/dev",
+			"target": "lib",
+			"weight": 2
+		},
+		{
+			"source": "client/legacy",
+			"target": "client",
+			"weight": 2
+		},
+		{
+			"source": "client",
+			"target": "server/dev",
+			"weight": 2
+		},
+		{
+			"source": "client",
+			"target": "build/analysis",
+			"weight": 2
+		},
+		{
+			"source": "client",
+			"target": "client/lib",
+			"weight": 2
+		},
+		{
+			"source": "client/react-client-callbacks",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "client/request",
+			"target": "server/web",
+			"weight": 2
+		},
+		{
+			"source": "client/tracing",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "diagnostics",
+			"target": "trace",
+			"weight": 2
+		},
+		{
+			"source": "experimental/testing",
+			"target": "server/web",
+			"weight": 2
+		},
+		{
+			"source": "export/helpers",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "export/helpers",
+			"target": "lib",
+			"weight": 2
+		},
+		{
+			"source": "export/helpers",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "export/helpers",
+			"target": "client/components",
+			"weight": 2
+		},
+		{
+			"source": "export",
+			"target": "trace",
+			"weight": 2
+		},
+		{
+			"source": "export/routes",
+			"target": "export/helpers",
+			"weight": 2
+		},
+		{
+			"source": "export/routes",
+			"target": "server/after",
+			"weight": 2
+		},
+		{
+			"source": "export",
+			"target": "server/app-render",
+			"weight": 2
+		},
+		{
+			"source": "export",
+			"target": "server/resume-data-cache",
+			"weight": 2
+		},
+		{
+			"source": "lib",
+			"target": "(root)",
+			"weight": 2
+		},
+		{
+			"source": "lib/metadata",
+			"target": "build/webpack",
+			"weight": 2
+		},
+		{
+			"source": "lib/metadata",
+			"target": "build/output",
+			"weight": 2
+		},
+		{
+			"source": "lib/metadata",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "lib/typescript",
+			"target": "build/output",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools",
+			"target": "next-devtools/shared",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools",
+			"target": "server/dev",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "build/output",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "next-devtools/shared",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "telemetry",
+			"weight": 2
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "client/dev",
+			"weight": 2
+		},
+		{
+			"source": "pages",
+			"target": "client",
+			"weight": 2
+		},
+		{
+			"source": "pages",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "pages",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "server/after",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "server/api-utils",
+			"target": "server/base-http",
+			"weight": 2
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/response-cache",
+			"weight": 2
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/request",
+			"weight": 2
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "server",
+			"target": "build/static-paths",
+			"weight": 2
+		},
+		{
+			"source": "server",
+			"target": "cli",
+			"weight": 2
+		},
+		{
+			"source": "server",
+			"target": "build/swc",
+			"weight": 2
+		},
+		{
+			"source": "server/dev",
+			"target": "server/api-utils",
+			"weight": 2
+		},
+		{
+			"source": "server/dev",
+			"target": "lib/metadata",
+			"weight": 2
+		},
+		{
+			"source": "server/dev",
+			"target": "telemetry",
+			"weight": 2
+		},
+		{
+			"source": "server/dev",
+			"target": "next-devtools/userspace",
+			"weight": 2
+		},
+		{
+			"source": "server/dev",
+			"target": "build/segment-config",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "telemetry",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "server/request",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "(root)",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "server/instrumentation",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "build/swc",
+			"weight": 2
+		},
+		{
+			"source": "server/lib",
+			"target": "telemetry/events",
+			"weight": 2
+		},
+		{
+			"source": "server/mcp",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "server/mcp",
+			"target": "next-devtools/server",
+			"weight": 2
+		},
+		{
+			"source": "server",
+			"target": "next-devtools/userspace",
+			"weight": 2
+		},
+		{
+			"source": "server/request",
+			"target": "server/route-modules",
+			"weight": 2
+		},
+		{
+			"source": "server/resume-data-cache",
+			"target": "server/app-render",
+			"weight": 2
+		},
+		{
+			"source": "server/resume-data-cache",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "lib",
+			"weight": 2
+		},
+		{
+			"source": "server/route-matchers",
+			"target": "server/route-matches",
+			"weight": 2
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/request",
+			"weight": 2
+		},
+		{
+			"source": "server/route-modules",
+			"target": "build/segment-config",
+			"weight": 2
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "server/stream-utils",
+			"target": "server/lib",
+			"weight": 2
+		},
+		{
+			"source": "server/stream-utils",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "server/use-cache",
+			"target": "lib",
+			"weight": 2
+		},
+		{
+			"source": "server/use-cache",
+			"target": "client/components",
+			"weight": 2
+		},
+		{
+			"source": "server/use-cache",
+			"target": "server/web",
+			"weight": 2
+		},
+		{
+			"source": "server/web",
+			"target": "server/async-storage",
+			"weight": 2
+		},
+		{
+			"source": "server/web",
+			"target": "server/route-modules",
+			"weight": 2
+		},
+		{
+			"source": "server/web",
+			"target": "server/use-cache",
+			"weight": 2
+		},
+		{
+			"source": "server/web",
+			"target": "server/instrumentation",
+			"weight": 2
+		},
+		{
+			"source": "server/web",
+			"target": "build/segment-config",
+			"weight": 2
+		},
+		{
+			"source": "shared/lib",
+			"target": "server/api-utils",
+			"weight": 2
+		},
+		{
+			"source": "shared/lib",
+			"target": "next-devtools/dev-overlay",
+			"weight": 2
+		},
+		{
+			"source": "shared/lib",
+			"target": "server/base-http",
+			"weight": 2
+		},
+		{
+			"source": "telemetry/events",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "trace/report",
+			"target": "shared/lib",
+			"weight": 2
+		},
+		{
+			"source": "trace",
+			"target": "lib/helpers",
+			"weight": 2
+		},
+		{
+			"source": "(root)",
+			"target": "server",
+			"weight": 2
+		},
+		{
+			"source": "(root)",
+			"target": "build/adapter",
+			"weight": 2
+		},
+		{
+			"source": "api",
+			"target": "server/og",
+			"weight": 1
+		},
+		{
+			"source": "api",
+			"target": "server/web",
+			"weight": 1
+		},
+		{
+			"source": "bin",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "bin",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/adapter",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/adapter",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "build/analysis",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "build/analysis",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/analysis",
+			"target": "build/webpack",
+			"weight": 1
+		},
+		{
+			"source": "build/analysis",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "build/analyze",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "build/analyze",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/analyze",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "build/analyze",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "build/analyze",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "build/babel",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/babel",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "build/babel",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "build/babel",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "build/webpack-build",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "build/manifests",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "lib/memory",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "server/app-render",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "build/turbopack-build",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "build/adapter",
+			"weight": 1
+		},
+		{
+			"source": "build/jest",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "build/jest",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "build/jest",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "build/jest",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/jest",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "lib/typescript",
+			"weight": 1
+		},
+		{
+			"source": "build/next-config-ts",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "server/normalizers",
+			"weight": 1
+		},
+		{
+			"source": "build/output",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "build/segment-config",
+			"target": "server/request",
+			"weight": 1
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server/after",
+			"weight": 1
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server/async-storage",
+			"weight": 1
+		},
+		{
+			"source": "build/static-paths",
+			"target": "export/helpers",
+			"weight": 1
+		},
+		{
+			"source": "build/static-paths",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "build/static-paths",
+			"target": "(root)",
+			"weight": 1
+		},
+		{
+			"source": "build/swc",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/swc",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "build/swc",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "build/templates",
+			"target": "build/static-paths",
+			"weight": 1
+		},
+		{
+			"source": "build/templates",
+			"target": "build/adapter",
+			"weight": 1
+		},
+		{
+			"source": "build/templates",
+			"target": "(root)",
+			"weight": 1
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "build/turbopack-analyze",
+			"target": "trace",
+			"weight": 1
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "export",
+			"weight": 1
+		},
+		{
+			"source": "build/turbopack-build",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "server/web",
+			"weight": 1
+		},
+		{
+			"source": "build",
+			"target": "export/helpers",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack",
+			"target": "server/route-modules",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack",
+			"target": "server/use-cache",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack",
+			"target": "server/app-render",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "build/webpack-build",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "cli/internal",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "cli/internal",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "cli",
+			"target": "build/analyze",
+			"weight": 1
+		},
+		{
+			"source": "cli",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "cli",
+			"target": "server/dev",
+			"weight": 1
+		},
+		{
+			"source": "cli",
+			"target": "next-devtools/shared",
+			"weight": 1
+		},
+		{
+			"source": "client",
+			"target": "next-devtools/userspace",
+			"weight": 1
+		},
+		{
+			"source": "client/compat",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "client/compat",
+			"target": "client",
+			"weight": 1
+		},
+		{
+			"source": "client/components",
+			"target": "lib/framework",
+			"weight": 1
+		},
+		{
+			"source": "client/components",
+			"target": "client/dev",
+			"weight": 1
+		},
+		{
+			"source": "client/components",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "client/components",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "client/dev",
+			"target": "next-devtools/shared",
+			"weight": 1
+		},
+		{
+			"source": "client/dev",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "client",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "client",
+			"target": "client/portal",
+			"weight": 1
+		},
+		{
+			"source": "client",
+			"target": "client/tracing",
+			"weight": 1
+		},
+		{
+			"source": "client/lib",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "client/lib",
+			"target": "client",
+			"weight": 1
+		},
+		{
+			"source": "client/react-client-callbacks",
+			"target": "next-devtools/userspace",
+			"weight": 1
+		},
+		{
+			"source": "client/react-client-callbacks",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "client",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "client/tracing",
+			"target": "client/dev",
+			"weight": 1
+		},
+		{
+			"source": "diagnostics",
+			"target": "export",
+			"weight": 1
+		},
+		{
+			"source": "diagnostics",
+			"target": "server/base-http",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testing",
+			"target": "server/request",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testing",
+			"target": "server/route-modules",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testing",
+			"target": "build/analysis",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testing",
+			"target": "build/segment-config",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testing",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testmode",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "experimental/testmode",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "export/helpers",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "export/helpers",
+			"target": "server/app-render",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "build/manifests",
+			"weight": 1
+		},
+		{
+			"source": "export/routes",
+			"target": "client/components",
+			"weight": 1
+		},
+		{
+			"source": "export/routes",
+			"target": "server/resume-data-cache",
+			"weight": 1
+		},
+		{
+			"source": "export/routes",
+			"target": "lib/metadata",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "server/base-http",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "client/components",
+			"weight": 1
+		},
+		{
+			"source": "export",
+			"target": "server/node-environment-extensions",
+			"weight": 1
+		},
+		{
+			"source": "lib/helpers",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "lib/helpers",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "lib/metadata",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "lib/metadata",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "lib/metadata",
+			"target": "client/components",
+			"weight": 1
+		},
+		{
+			"source": "lib/typescript",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "lib/typescript",
+			"target": "lib/helpers",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/dev-overlay",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools",
+			"target": "next-devtools/userspace",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "server/dev",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "next-devtools/dev-overlay",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "build/webpack",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/server",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/shared",
+			"target": "next-devtools/dev-overlay",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/shared",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/shared",
+			"target": "server/dev",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "client",
+			"weight": 1
+		},
+		{
+			"source": "next-devtools/userspace",
+			"target": "client/react-client-callbacks",
+			"weight": 1
+		},
+		{
+			"source": "pages",
+			"target": "build/webpack",
+			"weight": 1
+		},
+		{
+			"source": "pages",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "server/after",
+			"target": "server/web",
+			"weight": 1
+		},
+		{
+			"source": "server/api-utils",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "server/api-utils",
+			"target": "server/instrumentation",
+			"weight": 1
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/dev",
+			"weight": 1
+		},
+		{
+			"source": "server/app-render",
+			"target": "build/swc",
+			"weight": 1
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "server/app-render",
+			"target": "next-devtools/dev-overlay",
+			"weight": 1
+		},
+		{
+			"source": "server/app-render",
+			"target": "server/after",
+			"weight": 1
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/response-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/resume-data-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/async-storage",
+			"target": "build/segment-config",
+			"weight": 1
+		},
+		{
+			"source": "server/async-storage",
+			"target": "server/after",
+			"weight": 1
+		},
+		{
+			"source": "server/async-storage",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/base-http",
+			"target": "client/components",
+			"weight": 1
+		},
+		{
+			"source": "server/base-http",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "server/base-http",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "build/analysis",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "server/instrumentation",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "api",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "build/next-config-ts",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "build/adapter",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "server/mcp",
+			"weight": 1
+		},
+		{
+			"source": "server/dev",
+			"target": "server/request",
+			"weight": 1
+		},
+		{
+			"source": "server/dev",
+			"target": "server/response-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/dev",
+			"target": "client",
+			"weight": 1
+		},
+		{
+			"source": "server/dev",
+			"target": "export/helpers",
+			"weight": 1
+		},
+		{
+			"source": "server/dev",
+			"target": "server/after",
+			"weight": 1
+		},
+		{
+			"source": "server/dev",
+			"target": "server/async-storage",
+			"weight": 1
+		},
+		{
+			"source": "server/lib",
+			"target": "export/routes",
+			"weight": 1
+		},
+		{
+			"source": "server/lib",
+			"target": "server/route-modules",
+			"weight": 1
+		},
+		{
+			"source": "server/lib",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "server/lib",
+			"target": "next-devtools/dev-overlay",
+			"weight": 1
+		},
+		{
+			"source": "server/lib",
+			"target": "build/analysis",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "lib/metadata",
+			"weight": 1
+		},
+		{
+			"source": "server/mcp",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "server/mcp",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "server/mcp",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "server/typescript",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "server/dev",
+			"weight": 1
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "server/dev",
+			"weight": 1
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "client/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/node-environment-extensions",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/normalizers",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "next-devtools/server",
+			"weight": 1
+		},
+		{
+			"source": "server",
+			"target": "server/resume-data-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/request",
+			"target": "server/async-storage",
+			"weight": 1
+		},
+		{
+			"source": "server/request",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/response-cache",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "server/resume-data-cache",
+			"target": "server/response-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/resume-data-cache",
+			"target": "server/stream-utils",
+			"weight": 1
+		},
+		{
+			"source": "server/resume-data-cache",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matcher-managers",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matcher-providers",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matchers",
+			"target": "server/lib",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matchers",
+			"target": "server/request",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matches",
+			"target": "server",
+			"weight": 1
+		},
+		{
+			"source": "server/route-matches",
+			"target": "server/request",
+			"weight": 1
+		},
+		{
+			"source": "server/route-modules",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "server/route-modules",
+			"target": "server/resume-data-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/route-modules",
+			"target": "build/adapter",
+			"weight": 1
+		},
+		{
+			"source": "server/route-modules",
+			"target": "build/webpack",
+			"weight": 1
+		},
+		{
+			"source": "server/route-modules",
+			"target": "lib/metadata",
+			"weight": 1
+		},
+		{
+			"source": "server/stream-utils",
+			"target": "server/app-render",
+			"weight": 1
+		},
+		{
+			"source": "server/typescript",
+			"target": "build/segment-config",
+			"weight": 1
+		},
+		{
+			"source": "server/use-cache",
+			"target": "build/webpack",
+			"weight": 1
+		},
+		{
+			"source": "server/use-cache",
+			"target": "server/resume-data-cache",
+			"weight": 1
+		},
+		{
+			"source": "server/use-cache",
+			"target": "build/output",
+			"weight": 1
+		},
+		{
+			"source": "server/web",
+			"target": "server/route-matchers",
+			"weight": 1
+		},
+		{
+			"source": "server/web",
+			"target": "server/request",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "lib/metadata",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "client/lib",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "build/analysis",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "lib/memory",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "telemetry/events",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "lib/fs",
+			"weight": 1
+		},
+		{
+			"source": "shared/lib",
+			"target": "build",
+			"weight": 1
+		},
+		{
+			"source": "telemetry",
+			"target": "shared/lib",
+			"weight": 1
+		},
+		{
+			"source": "telemetry/events",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "telemetry/events",
+			"target": "trace",
+			"weight": 1
+		},
+		{
+			"source": "telemetry/events",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "telemetry",
+			"target": "trace",
+			"weight": 1
+		},
+		{
+			"source": "trace/report",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "trace",
+			"target": "trace/report",
+			"weight": 1
+		},
+		{
+			"source": "trace",
+			"target": "telemetry",
+			"weight": 1
+		},
+		{
+			"source": "(root)",
+			"target": "lib",
+			"weight": 1
+		},
+		{
+			"source": "(root)",
+			"target": "server/api-utils",
+			"weight": 1
+		},
+		{
+			"source": "(root)",
+			"target": "build/segment-config",
+			"weight": 1
+		},
+		{
+			"source": "(root)",
+			"target": "server/instrumentation",
+			"weight": 1
+		}
+	]
 }

--- a/site/lib/data/nextjs-depgraph.json
+++ b/site/lib/data/nextjs-depgraph.json
@@ -1,0 +1,4403 @@
+{
+  "meta": {
+    "source": "vercel/next.js \u00b7 packages/next/src",
+    "parser": "graph-sitter (rust backend)",
+    "parse_seconds": 4.89,
+    "files": 1680,
+    "modules": 91,
+    "edges": 710,
+    "symbols": 16004
+  },
+  "groups": [
+    "(root)",
+    "api",
+    "bin",
+    "build",
+    "bundles",
+    "cli",
+    "client",
+    "diagnostics",
+    "experimental",
+    "export",
+    "lib",
+    "next-devtools",
+    "pages",
+    "server",
+    "shared",
+    "telemetry",
+    "trace"
+  ],
+  "nodes": [
+    {
+      "id": "(root)",
+      "group": "(root)",
+      "files": 1,
+      "loc": 327,
+      "symbols": 20,
+      "inbound": 42,
+      "outbound": 24
+    },
+    {
+      "id": "api",
+      "group": "api",
+      "files": 18,
+      "loc": 39,
+      "symbols": 1,
+      "inbound": 1,
+      "outbound": 33
+    },
+    {
+      "id": "bin",
+      "group": "bin",
+      "files": 1,
+      "loc": 763,
+      "symbols": 11,
+      "inbound": 0,
+      "outbound": 10
+    },
+    {
+      "id": "build",
+      "group": "build",
+      "files": 43,
+      "loc": 16061,
+      "symbols": 978,
+      "inbound": 164,
+      "outbound": 491
+    },
+    {
+      "id": "build/adapter",
+      "group": "build",
+      "files": 2,
+      "loc": 2427,
+      "symbols": 60,
+      "inbound": 6,
+      "outbound": 39
+    },
+    {
+      "id": "build/analysis",
+      "group": "build",
+      "files": 4,
+      "loc": 1280,
+      "symbols": 63,
+      "inbound": 29,
+      "outbound": 36
+    },
+    {
+      "id": "build/analyze",
+      "group": "build",
+      "files": 1,
+      "loc": 234,
+      "symbols": 10,
+      "inbound": 1,
+      "outbound": 20
+    },
+    {
+      "id": "build/babel",
+      "group": "build",
+      "files": 14,
+      "loc": 2353,
+      "symbols": 114,
+      "inbound": 1,
+      "outbound": 10
+    },
+    {
+      "id": "build/jest",
+      "group": "build",
+      "files": 6,
+      "loc": 286,
+      "symbols": 26,
+      "inbound": 0,
+      "outbound": 8
+    },
+    {
+      "id": "build/manifests",
+      "group": "build",
+      "files": 1,
+      "loc": 8,
+      "symbols": 1,
+      "inbound": 2,
+      "outbound": 0
+    },
+    {
+      "id": "build/next-config-ts",
+      "group": "build",
+      "files": 2,
+      "loc": 297,
+      "symbols": 16,
+      "inbound": 1,
+      "outbound": 3
+    },
+    {
+      "id": "build/output",
+      "group": "build",
+      "files": 4,
+      "loc": 566,
+      "symbols": 45,
+      "inbound": 87,
+      "outbound": 15
+    },
+    {
+      "id": "build/polyfills",
+      "group": "build",
+      "files": 10,
+      "loc": 36,
+      "symbols": 4,
+      "inbound": 2,
+      "outbound": 0
+    },
+    {
+      "id": "build/segment-config",
+      "group": "build",
+      "files": 5,
+      "loc": 805,
+      "symbols": 41,
+      "inbound": 38,
+      "outbound": 21
+    },
+    {
+      "id": "build/static-paths",
+      "group": "build",
+      "files": 8,
+      "loc": 5709,
+      "symbols": 62,
+      "inbound": 16,
+      "outbound": 58
+    },
+    {
+      "id": "build/swc",
+      "group": "build",
+      "files": 9,
+      "loc": 3974,
+      "symbols": 239,
+      "inbound": 95,
+      "outbound": 25
+    },
+    {
+      "id": "build/templates",
+      "group": "build",
+      "files": 11,
+      "loc": 4190,
+      "symbols": 188,
+      "inbound": 0,
+      "outbound": 189
+    },
+    {
+      "id": "build/turbopack-analyze",
+      "group": "build",
+      "files": 1,
+      "loc": 130,
+      "symbols": 4,
+      "inbound": 2,
+      "outbound": 11
+    },
+    {
+      "id": "build/turbopack-build",
+      "group": "build",
+      "files": 2,
+      "loc": 467,
+      "symbols": 8,
+      "inbound": 1,
+      "outbound": 33
+    },
+    {
+      "id": "build/turborepo-access-trace",
+      "group": "build",
+      "files": 6,
+      "loc": 289,
+      "symbols": 14,
+      "inbound": 8,
+      "outbound": 0
+    },
+    {
+      "id": "build/webpack",
+      "group": "build",
+      "files": 140,
+      "loc": 21358,
+      "symbols": 1965,
+      "inbound": 113,
+      "outbound": 285
+    },
+    {
+      "id": "build/webpack-build",
+      "group": "build",
+      "files": 2,
+      "loc": 623,
+      "symbols": 33,
+      "inbound": 1,
+      "outbound": 45
+    },
+    {
+      "id": "build/webpack-config-rules",
+      "group": "build",
+      "files": 1,
+      "loc": 30,
+      "symbols": 3,
+      "inbound": 2,
+      "outbound": 2
+    },
+    {
+      "id": "bundles",
+      "group": "bundles",
+      "files": 1,
+      "loc": 7,
+      "symbols": 1,
+      "inbound": 0,
+      "outbound": 0
+    },
+    {
+      "id": "bundles/babel",
+      "group": "bundles",
+      "files": 29,
+      "loc": 255,
+      "symbols": 44,
+      "inbound": 0,
+      "outbound": 0
+    },
+    {
+      "id": "bundles/cssnano-simple",
+      "group": "bundles",
+      "files": 3,
+      "loc": 203,
+      "symbols": 7,
+      "inbound": 0,
+      "outbound": 0
+    },
+    {
+      "id": "bundles/postcss-plugin-stub",
+      "group": "bundles",
+      "files": 1,
+      "loc": 25,
+      "symbols": 1,
+      "inbound": 0,
+      "outbound": 0
+    },
+    {
+      "id": "bundles/webpack",
+      "group": "bundles",
+      "files": 26,
+      "loc": 1114,
+      "symbols": 40,
+      "inbound": 0,
+      "outbound": 0
+    },
+    {
+      "id": "cli",
+      "group": "cli",
+      "files": 11,
+      "loc": 1981,
+      "symbols": 208,
+      "inbound": 2,
+      "outbound": 114
+    },
+    {
+      "id": "cli/internal",
+      "group": "cli",
+      "files": 4,
+      "loc": 1819,
+      "symbols": 104,
+      "inbound": 0,
+      "outbound": 4
+    },
+    {
+      "id": "client",
+      "group": "client",
+      "files": 53,
+      "loc": 6685,
+      "symbols": 470,
+      "inbound": 92,
+      "outbound": 167
+    },
+    {
+      "id": "client/app-dir",
+      "group": "client",
+      "files": 3,
+      "loc": 1090,
+      "symbols": 25,
+      "inbound": 0,
+      "outbound": 30
+    },
+    {
+      "id": "client/compat",
+      "group": "client",
+      "files": 1,
+      "loc": 17,
+      "symbols": 1,
+      "inbound": 0,
+      "outbound": 2
+    },
+    {
+      "id": "client/components",
+      "group": "client",
+      "files": 103,
+      "loc": 20577,
+      "symbols": 786,
+      "inbound": 215,
+      "outbound": 244
+    },
+    {
+      "id": "client/dev",
+      "group": "client",
+      "files": 15,
+      "loc": 2544,
+      "symbols": 154,
+      "inbound": 14,
+      "outbound": 49
+    },
+    {
+      "id": "client/legacy",
+      "group": "client",
+      "files": 1,
+      "loc": 1202,
+      "symbols": 57,
+      "inbound": 0,
+      "outbound": 12
+    },
+    {
+      "id": "client/lib",
+      "group": "client",
+      "files": 3,
+      "loc": 225,
+      "symbols": 9,
+      "inbound": 9,
+      "outbound": 2
+    },
+    {
+      "id": "client/portal",
+      "group": "client",
+      "files": 1,
+      "loc": 22,
+      "symbols": 5,
+      "inbound": 1,
+      "outbound": 0
+    },
+    {
+      "id": "client/react-client-callbacks",
+      "group": "client",
+      "files": 3,
+      "loc": 170,
+      "symbols": 12,
+      "inbound": 7,
+      "outbound": 7
+    },
+    {
+      "id": "client/request",
+      "group": "client",
+      "files": 7,
+      "loc": 262,
+      "symbols": 27,
+      "inbound": 0,
+      "outbound": 11
+    },
+    {
+      "id": "client/tracing",
+      "group": "client",
+      "files": 2,
+      "loc": 97,
+      "symbols": 6,
+      "inbound": 1,
+      "outbound": 3
+    },
+    {
+      "id": "diagnostics",
+      "group": "diagnostics",
+      "files": 2,
+      "loc": 183,
+      "symbols": 13,
+      "inbound": 3,
+      "outbound": 4
+    },
+    {
+      "id": "experimental/testing",
+      "group": "experimental",
+      "files": 6,
+      "loc": 902,
+      "symbols": 12,
+      "inbound": 0,
+      "outbound": 25
+    },
+    {
+      "id": "experimental/testmode",
+      "group": "experimental",
+      "files": 18,
+      "loc": 1035,
+      "symbols": 95,
+      "inbound": 0,
+      "outbound": 2
+    },
+    {
+      "id": "export",
+      "group": "export",
+      "files": 4,
+      "loc": 1951,
+      "symbols": 80,
+      "inbound": 8,
+      "outbound": 112
+    },
+    {
+      "id": "export/helpers",
+      "group": "export",
+      "files": 3,
+      "loc": 130,
+      "symbols": 4,
+      "inbound": 9,
+      "outbound": 14
+    },
+    {
+      "id": "export/routes",
+      "group": "export",
+      "files": 4,
+      "loc": 626,
+      "symbols": 6,
+      "inbound": 5,
+      "outbound": 66
+    },
+    {
+      "id": "lib",
+      "group": "lib",
+      "files": 79,
+      "loc": 8684,
+      "symbols": 432,
+      "inbound": 694,
+      "outbound": 68
+    },
+    {
+      "id": "lib/framework",
+      "group": "lib",
+      "files": 2,
+      "loc": 56,
+      "symbols": 9,
+      "inbound": 9,
+      "outbound": 0
+    },
+    {
+      "id": "lib/fs",
+      "group": "lib",
+      "files": 2,
+      "loc": 130,
+      "symbols": 3,
+      "inbound": 1,
+      "outbound": 0
+    },
+    {
+      "id": "lib/helpers",
+      "group": "lib",
+      "files": 8,
+      "loc": 413,
+      "symbols": 17,
+      "inbound": 20,
+      "outbound": 2
+    },
+    {
+      "id": "lib/memory",
+      "group": "lib",
+      "files": 4,
+      "loc": 240,
+      "symbols": 19,
+      "inbound": 4,
+      "outbound": 14
+    },
+    {
+      "id": "lib/metadata",
+      "group": "lib",
+      "files": 29,
+      "loc": 8357,
+      "symbols": 303,
+      "inbound": 47,
+      "outbound": 51
+    },
+    {
+      "id": "lib/typescript",
+      "group": "lib",
+      "files": 9,
+      "loc": 1624,
+      "symbols": 53,
+      "inbound": 6,
+      "outbound": 21
+    },
+    {
+      "id": "next-devtools",
+      "group": "next-devtools",
+      "files": 4,
+      "loc": 494,
+      "symbols": 24,
+      "inbound": 14,
+      "outbound": 39
+    },
+    {
+      "id": "next-devtools/dev-overlay",
+      "group": "next-devtools",
+      "files": 158,
+      "loc": 19418,
+      "symbols": 1100,
+      "inbound": 48,
+      "outbound": 93
+    },
+    {
+      "id": "next-devtools/server",
+      "group": "next-devtools",
+      "files": 11,
+      "loc": 1090,
+      "symbols": 65,
+      "inbound": 41,
+      "outbound": 18
+    },
+    {
+      "id": "next-devtools/shared",
+      "group": "next-devtools",
+      "files": 12,
+      "loc": 658,
+      "symbols": 47,
+      "inbound": 55,
+      "outbound": 7
+    },
+    {
+      "id": "next-devtools/userspace",
+      "group": "next-devtools",
+      "files": 17,
+      "loc": 1573,
+      "symbols": 144,
+      "inbound": 18,
+      "outbound": 39
+    },
+    {
+      "id": "pages",
+      "group": "pages",
+      "files": 3,
+      "loc": 1211,
+      "symbols": 120,
+      "inbound": 9,
+      "outbound": 28
+    },
+    {
+      "id": "server",
+      "group": "server",
+      "files": 55,
+      "loc": 20000,
+      "symbols": 994,
+      "inbound": 447,
+      "outbound": 497
+    },
+    {
+      "id": "server/after",
+      "group": "server",
+      "files": 8,
+      "loc": 1176,
+      "symbols": 32,
+      "inbound": 16,
+      "outbound": 19
+    },
+    {
+      "id": "server/api-utils",
+      "group": "server",
+      "files": 6,
+      "loc": 932,
+      "symbols": 37,
+      "inbound": 38,
+      "outbound": 28
+    },
+    {
+      "id": "server/app-render",
+      "group": "server",
+      "files": 88,
+      "loc": 26740,
+      "symbols": 1371,
+      "inbound": 322,
+      "outbound": 437
+    },
+    {
+      "id": "server/async-storage",
+      "group": "server",
+      "files": 4,
+      "loc": 629,
+      "symbols": 22,
+      "inbound": 13,
+      "outbound": 43
+    },
+    {
+      "id": "server/base-http",
+      "group": "server",
+      "files": 5,
+      "loc": 504,
+      "symbols": 23,
+      "inbound": 66,
+      "outbound": 14
+    },
+    {
+      "id": "server/dev",
+      "group": "server",
+      "files": 31,
+      "loc": 12369,
+      "symbols": 782,
+      "inbound": 63,
+      "outbound": 401
+    },
+    {
+      "id": "server/instrumentation",
+      "group": "server",
+      "files": 2,
+      "loc": 42,
+      "symbols": 6,
+      "inbound": 16,
+      "outbound": 0
+    },
+    {
+      "id": "server/lib",
+      "group": "server",
+      "files": 94,
+      "loc": 17745,
+      "symbols": 1208,
+      "inbound": 378,
+      "outbound": 354
+    },
+    {
+      "id": "server/mcp",
+      "group": "server",
+      "files": 17,
+      "loc": 1780,
+      "symbols": 112,
+      "inbound": 13,
+      "outbound": 26
+    },
+    {
+      "id": "server/node-environment-extensions",
+      "group": "server",
+      "files": 17,
+      "loc": 6111,
+      "symbols": 176,
+      "inbound": 16,
+      "outbound": 30
+    },
+    {
+      "id": "server/normalizers",
+      "group": "server",
+      "files": 30,
+      "loc": 745,
+      "symbols": 38,
+      "inbound": 27,
+      "outbound": 18
+    },
+    {
+      "id": "server/og",
+      "group": "server",
+      "files": 1,
+      "loc": 64,
+      "symbols": 12,
+      "inbound": 1,
+      "outbound": 0
+    },
+    {
+      "id": "server/request",
+      "group": "server",
+      "files": 12,
+      "loc": 4140,
+      "symbols": 132,
+      "inbound": 89,
+      "outbound": 172
+    },
+    {
+      "id": "server/response-cache",
+      "group": "server",
+      "files": 5,
+      "loc": 1142,
+      "symbols": 78,
+      "inbound": 63,
+      "outbound": 16
+    },
+    {
+      "id": "server/resume-data-cache",
+      "group": "server",
+      "files": 3,
+      "loc": 654,
+      "symbols": 22,
+      "inbound": 21,
+      "outbound": 7
+    },
+    {
+      "id": "server/route-definitions",
+      "group": "server",
+      "files": 6,
+      "loc": 66,
+      "symbols": 7,
+      "inbound": 38,
+      "outbound": 6
+    },
+    {
+      "id": "server/route-matcher-managers",
+      "group": "server",
+      "files": 4,
+      "loc": 796,
+      "symbols": 33,
+      "inbound": 7,
+      "outbound": 27
+    },
+    {
+      "id": "server/route-matcher-providers",
+      "group": "server",
+      "files": 27,
+      "loc": 1863,
+      "symbols": 98,
+      "inbound": 15,
+      "outbound": 81
+    },
+    {
+      "id": "server/route-matchers",
+      "group": "server",
+      "files": 6,
+      "loc": 177,
+      "symbols": 13,
+      "inbound": 22,
+      "outbound": 14
+    },
+    {
+      "id": "server/route-matches",
+      "group": "server",
+      "files": 6,
+      "loc": 56,
+      "symbols": 7,
+      "inbound": 10,
+      "outbound": 8
+    },
+    {
+      "id": "server/route-modules",
+      "group": "server",
+      "files": 64,
+      "loc": 4996,
+      "symbols": 371,
+      "inbound": 64,
+      "outbound": 246
+    },
+    {
+      "id": "server/stream-utils",
+      "group": "server",
+      "files": 4,
+      "loc": 1471,
+      "symbols": 141,
+      "inbound": 40,
+      "outbound": 13
+    },
+    {
+      "id": "server/typescript",
+      "group": "server",
+      "files": 10,
+      "loc": 2140,
+      "symbols": 240,
+      "inbound": 1,
+      "outbound": 1
+    },
+    {
+      "id": "server/use-cache",
+      "group": "server",
+      "files": 10,
+      "loc": 4423,
+      "symbols": 142,
+      "inbound": 27,
+      "outbound": 68
+    },
+    {
+      "id": "server/web",
+      "group": "server",
+      "files": 36,
+      "loc": 4955,
+      "symbols": 283,
+      "inbound": 119,
+      "outbound": 114
+    },
+    {
+      "id": "shared/lib",
+      "group": "shared",
+      "files": 164,
+      "loc": 17875,
+      "symbols": 1037,
+      "inbound": 1393,
+      "outbound": 123
+    },
+    {
+      "id": "telemetry",
+      "group": "telemetry",
+      "files": 8,
+      "loc": 714,
+      "symbols": 40,
+      "inbound": 22,
+      "outbound": 9
+    },
+    {
+      "id": "telemetry/events",
+      "group": "telemetry",
+      "files": 10,
+      "loc": 889,
+      "symbols": 57,
+      "inbound": 22,
+      "outbound": 8
+    },
+    {
+      "id": "trace",
+      "group": "trace",
+      "files": 7,
+      "loc": 769,
+      "symbols": 56,
+      "inbound": 88,
+      "outbound": 4
+    },
+    {
+      "id": "trace/report",
+      "group": "trace",
+      "files": 6,
+      "loc": 325,
+      "symbols": 25,
+      "inbound": 1,
+      "outbound": 12
+    }
+  ],
+  "edges": [
+    {
+      "source": "server",
+      "target": "shared/lib",
+      "weight": 175
+    },
+    {
+      "source": "client/components",
+      "target": "shared/lib",
+      "weight": 171
+    },
+    {
+      "source": "server/app-render",
+      "target": "shared/lib",
+      "weight": 133
+    },
+    {
+      "source": "build",
+      "target": "lib",
+      "weight": 128
+    },
+    {
+      "source": "build",
+      "target": "shared/lib",
+      "weight": 114
+    },
+    {
+      "source": "client",
+      "target": "shared/lib",
+      "weight": 114
+    },
+    {
+      "source": "server/lib",
+      "target": "shared/lib",
+      "weight": 107
+    },
+    {
+      "source": "server/request",
+      "target": "server/app-render",
+      "weight": 100
+    },
+    {
+      "source": "build/webpack",
+      "target": "shared/lib",
+      "weight": 94
+    },
+    {
+      "source": "server/dev",
+      "target": "shared/lib",
+      "weight": 78
+    },
+    {
+      "source": "server",
+      "target": "server/lib",
+      "weight": 72
+    },
+    {
+      "source": "build/webpack",
+      "target": "lib",
+      "weight": 71
+    },
+    {
+      "source": "server",
+      "target": "lib",
+      "weight": 68
+    },
+    {
+      "source": "server/app-render",
+      "target": "client/components",
+      "weight": 64
+    },
+    {
+      "source": "server/lib",
+      "target": "lib",
+      "weight": 61
+    },
+    {
+      "source": "server/route-modules",
+      "target": "shared/lib",
+      "weight": 58
+    },
+    {
+      "source": "build",
+      "target": "build/webpack",
+      "weight": 50
+    },
+    {
+      "source": "server/lib",
+      "target": "server",
+      "weight": 47
+    },
+    {
+      "source": "build",
+      "target": "server",
+      "weight": 46
+    },
+    {
+      "source": "server/dev",
+      "target": "lib",
+      "weight": 46
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/lib",
+      "weight": 43
+    },
+    {
+      "source": "build/templates",
+      "target": "server/lib",
+      "weight": 42
+    },
+    {
+      "source": "cli",
+      "target": "lib",
+      "weight": 40
+    },
+    {
+      "source": "client/components",
+      "target": "client",
+      "weight": 40
+    },
+    {
+      "source": "server/dev",
+      "target": "server",
+      "weight": 39
+    },
+    {
+      "source": "server/app-render",
+      "target": "server",
+      "weight": 34
+    },
+    {
+      "source": "server/dev",
+      "target": "server/lib",
+      "weight": 34
+    },
+    {
+      "source": "server/dev",
+      "target": "build",
+      "weight": 34
+    },
+    {
+      "source": "server/dev",
+      "target": "next-devtools/server",
+      "weight": 34
+    },
+    {
+      "source": "server/use-cache",
+      "target": "server/app-render",
+      "weight": 34
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server",
+      "weight": 33
+    },
+    {
+      "source": "cli",
+      "target": "server/lib",
+      "weight": 32
+    },
+    {
+      "source": "next-devtools",
+      "target": "next-devtools/dev-overlay",
+      "weight": 32
+    },
+    {
+      "source": "build/webpack",
+      "target": "build",
+      "weight": 31
+    },
+    {
+      "source": "server/request",
+      "target": "server",
+      "weight": 31
+    },
+    {
+      "source": "build/templates",
+      "target": "server/web",
+      "weight": 30
+    },
+    {
+      "source": "export",
+      "target": "shared/lib",
+      "weight": 28
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "next-devtools/shared",
+      "weight": 28
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/stream-utils",
+      "weight": 28
+    },
+    {
+      "source": "build/templates",
+      "target": "server",
+      "weight": 27
+    },
+    {
+      "source": "server/dev",
+      "target": "build/swc",
+      "weight": 26
+    },
+    {
+      "source": "server/lib",
+      "target": "build",
+      "weight": 26
+    },
+    {
+      "source": "build/static-paths",
+      "target": "shared/lib",
+      "weight": 25
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "server/app-render",
+      "weight": 25
+    },
+    {
+      "source": "build",
+      "target": "server/lib",
+      "weight": 24
+    },
+    {
+      "source": "server/lib",
+      "target": "server/response-cache",
+      "weight": 24
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/app-render",
+      "weight": 23
+    },
+    {
+      "source": "shared/lib",
+      "target": "lib",
+      "weight": 23
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/lib",
+      "weight": 22
+    },
+    {
+      "source": "server/route-modules",
+      "target": "client/components",
+      "weight": 22
+    },
+    {
+      "source": "client/dev",
+      "target": "server/dev",
+      "weight": 20
+    },
+    {
+      "source": "export",
+      "target": "server",
+      "weight": 20
+    },
+    {
+      "source": "pages",
+      "target": "shared/lib",
+      "weight": 20
+    },
+    {
+      "source": "server/app-render",
+      "target": "lib",
+      "weight": 20
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/request",
+      "weight": 20
+    },
+    {
+      "source": "server/web",
+      "target": "server/app-render",
+      "weight": 19
+    },
+    {
+      "source": "build/webpack",
+      "target": "server",
+      "weight": 18
+    },
+    {
+      "source": "export",
+      "target": "lib",
+      "weight": 18
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "server/app-render",
+      "weight": 18
+    },
+    {
+      "source": "server/request",
+      "target": "shared/lib",
+      "weight": 18
+    },
+    {
+      "source": "lib",
+      "target": "shared/lib",
+      "weight": 17
+    },
+    {
+      "source": "lib/typescript",
+      "target": "lib",
+      "weight": 17
+    },
+    {
+      "source": "server/lib",
+      "target": "server/app-render",
+      "weight": 17
+    },
+    {
+      "source": "shared/lib",
+      "target": "client",
+      "weight": 17
+    },
+    {
+      "source": "build",
+      "target": "client/components",
+      "weight": 16
+    },
+    {
+      "source": "client",
+      "target": "client/components",
+      "weight": 16
+    },
+    {
+      "source": "client/components",
+      "target": "server/app-render",
+      "weight": 16
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/web",
+      "weight": 16
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "server",
+      "weight": 16
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "server/route-matchers",
+      "weight": 16
+    },
+    {
+      "source": "server/web",
+      "target": "shared/lib",
+      "weight": 16
+    },
+    {
+      "source": "server/web",
+      "target": "server",
+      "weight": 16
+    },
+    {
+      "source": "export/routes",
+      "target": "lib",
+      "weight": 15
+    },
+    {
+      "source": "lib/metadata",
+      "target": "shared/lib",
+      "weight": 15
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "next-devtools/shared",
+      "weight": 15
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "shared/lib",
+      "weight": 15
+    },
+    {
+      "source": "build/templates",
+      "target": "lib",
+      "weight": 14
+    },
+    {
+      "source": "build/webpack",
+      "target": "build/analysis",
+      "weight": 14
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "next-devtools",
+      "weight": 14
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/resume-data-cache",
+      "weight": 14
+    },
+    {
+      "source": "server",
+      "target": "server/app-render",
+      "weight": 14
+    },
+    {
+      "source": "server/web",
+      "target": "server/lib",
+      "weight": 14
+    },
+    {
+      "source": "build",
+      "target": "trace",
+      "weight": 13
+    },
+    {
+      "source": "build",
+      "target": "build/output",
+      "weight": 13
+    },
+    {
+      "source": "build/swc",
+      "target": "server",
+      "weight": 13
+    },
+    {
+      "source": "build/templates",
+      "target": "shared/lib",
+      "weight": 13
+    },
+    {
+      "source": "client/app-dir",
+      "target": "client/components",
+      "weight": 13
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/web",
+      "weight": 13
+    },
+    {
+      "source": "server",
+      "target": "server/base-http",
+      "weight": 13
+    },
+    {
+      "source": "shared/lib",
+      "target": "build/swc",
+      "weight": 13
+    },
+    {
+      "source": "build/adapter",
+      "target": "lib",
+      "weight": 12
+    },
+    {
+      "source": "build",
+      "target": "telemetry/events",
+      "weight": 12
+    },
+    {
+      "source": "build/analysis",
+      "target": "lib",
+      "weight": 12
+    },
+    {
+      "source": "build",
+      "target": "build/swc",
+      "weight": 12
+    },
+    {
+      "source": "build/templates",
+      "target": "server/route-modules",
+      "weight": 12
+    },
+    {
+      "source": "build/webpack",
+      "target": "build/swc",
+      "weight": 12
+    },
+    {
+      "source": "client/dev",
+      "target": "shared/lib",
+      "weight": 12
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "shared/lib",
+      "weight": 12
+    },
+    {
+      "source": "server",
+      "target": "server/response-cache",
+      "weight": 12
+    },
+    {
+      "source": "server",
+      "target": "build/webpack",
+      "weight": 12
+    },
+    {
+      "source": "server",
+      "target": "client/components",
+      "weight": 12
+    },
+    {
+      "source": "server",
+      "target": "server/web",
+      "weight": 12
+    },
+    {
+      "source": "server",
+      "target": "(root)",
+      "weight": 12
+    },
+    {
+      "source": "server/dev",
+      "target": "server/mcp",
+      "weight": 12
+    },
+    {
+      "source": "server",
+      "target": "server/node-environment-extensions",
+      "weight": 12
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/web",
+      "weight": 12
+    },
+    {
+      "source": "build/webpack",
+      "target": "lib/metadata",
+      "weight": 11
+    },
+    {
+      "source": "build/webpack",
+      "target": "server/dev",
+      "weight": 11
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "build",
+      "weight": 11
+    },
+    {
+      "source": "client/app-dir",
+      "target": "client",
+      "weight": 11
+    },
+    {
+      "source": "lib",
+      "target": "build/output",
+      "weight": 11
+    },
+    {
+      "source": "server",
+      "target": "server/route-modules",
+      "weight": 11
+    },
+    {
+      "source": "server/dev",
+      "target": "server/app-render",
+      "weight": 11
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "server/normalizers",
+      "weight": 11
+    },
+    {
+      "source": "server/route-modules",
+      "target": "lib",
+      "weight": 11
+    },
+    {
+      "source": "server/use-cache",
+      "target": "server/lib",
+      "weight": 11
+    },
+    {
+      "source": "shared/lib",
+      "target": "server/request",
+      "weight": 11
+    },
+    {
+      "source": "shared/lib",
+      "target": "server",
+      "weight": 11
+    },
+    {
+      "source": "shared/lib",
+      "target": "build/webpack",
+      "weight": 11
+    },
+    {
+      "source": "build/adapter",
+      "target": "shared/lib",
+      "weight": 10
+    },
+    {
+      "source": "build/analysis",
+      "target": "build/segment-config",
+      "weight": 10
+    },
+    {
+      "source": "client",
+      "target": "client/dev",
+      "weight": 10
+    },
+    {
+      "source": "client/legacy",
+      "target": "shared/lib",
+      "weight": 10
+    },
+    {
+      "source": "export/routes",
+      "target": "server",
+      "weight": 10
+    },
+    {
+      "source": "server/app-render",
+      "target": "build/segment-config",
+      "weight": 10
+    },
+    {
+      "source": "server/lib",
+      "target": "trace",
+      "weight": 10
+    },
+    {
+      "source": "server/route-modules",
+      "target": "(root)",
+      "weight": 10
+    },
+    {
+      "source": "api",
+      "target": "shared/lib",
+      "weight": 9
+    },
+    {
+      "source": "build/adapter",
+      "target": "build",
+      "weight": 9
+    },
+    {
+      "source": "build",
+      "target": "build/analysis",
+      "weight": 9
+    },
+    {
+      "source": "build/templates",
+      "target": "client/components",
+      "weight": 9
+    },
+    {
+      "source": "build/templates",
+      "target": "server/response-cache",
+      "weight": 9
+    },
+    {
+      "source": "cli",
+      "target": "lib/helpers",
+      "weight": 9
+    },
+    {
+      "source": "lib",
+      "target": "server",
+      "weight": 9
+    },
+    {
+      "source": "server/after",
+      "target": "server/app-render",
+      "weight": 9
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/base-http",
+      "weight": 9
+    },
+    {
+      "source": "server/normalizers",
+      "target": "shared/lib",
+      "weight": 9
+    },
+    {
+      "source": "server/request",
+      "target": "server/web",
+      "weight": 9
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/response-cache",
+      "weight": 9
+    },
+    {
+      "source": "trace/report",
+      "target": "trace",
+      "weight": 9
+    },
+    {
+      "source": "api",
+      "target": "client",
+      "weight": 8
+    },
+    {
+      "source": "build/segment-config",
+      "target": "server/route-modules",
+      "weight": 8
+    },
+    {
+      "source": "build/templates",
+      "target": "server/base-http",
+      "weight": 8
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "trace",
+      "weight": 8
+    },
+    {
+      "source": "client",
+      "target": "lib",
+      "weight": 8
+    },
+    {
+      "source": "lib",
+      "target": "lib/helpers",
+      "weight": 8
+    },
+    {
+      "source": "lib",
+      "target": "server/lib",
+      "weight": 8
+    },
+    {
+      "source": "lib/metadata",
+      "target": "server/lib",
+      "weight": 8
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "client/components",
+      "weight": 8
+    },
+    {
+      "source": "server/api-utils",
+      "target": "lib",
+      "weight": 8
+    },
+    {
+      "source": "server/dev",
+      "target": "server/route-definitions",
+      "weight": 8
+    },
+    {
+      "source": "server/dev",
+      "target": "build/output",
+      "weight": 8
+    },
+    {
+      "source": "server/dev",
+      "target": "trace",
+      "weight": 8
+    },
+    {
+      "source": "server/lib",
+      "target": "build/output",
+      "weight": 8
+    },
+    {
+      "source": "server/normalizers",
+      "target": "lib",
+      "weight": 8
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "server/route-definitions",
+      "weight": 8
+    },
+    {
+      "source": "server/route-modules",
+      "target": "build",
+      "weight": 8
+    },
+    {
+      "source": "server/web",
+      "target": "lib",
+      "weight": 8
+    },
+    {
+      "source": "build",
+      "target": "lib/metadata",
+      "weight": 7
+    },
+    {
+      "source": "build/segment-config",
+      "target": "shared/lib",
+      "weight": 7
+    },
+    {
+      "source": "build/templates",
+      "target": "server/app-render",
+      "weight": 7
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "trace",
+      "weight": 7
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "lib",
+      "weight": 7
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "shared/lib",
+      "weight": 7
+    },
+    {
+      "source": "export/routes",
+      "target": "server/lib",
+      "weight": 7
+    },
+    {
+      "source": "lib/metadata",
+      "target": "server/request",
+      "weight": 7
+    },
+    {
+      "source": "server/app-render",
+      "target": "build/webpack",
+      "weight": 7
+    },
+    {
+      "source": "server/dev",
+      "target": "server/route-matcher-providers",
+      "weight": 7
+    },
+    {
+      "source": "server/lib",
+      "target": "server/dev",
+      "weight": 7
+    },
+    {
+      "source": "server/lib",
+      "target": "lib/metadata",
+      "weight": 7
+    },
+    {
+      "source": "server/mcp",
+      "target": "server/dev",
+      "weight": 7
+    },
+    {
+      "source": "server/response-cache",
+      "target": "server",
+      "weight": 7
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "lib",
+      "weight": 7
+    },
+    {
+      "source": "server/web",
+      "target": "client/components",
+      "weight": 7
+    },
+    {
+      "source": "server/web",
+      "target": "server/base-http",
+      "weight": 7
+    },
+    {
+      "source": "(root)",
+      "target": "lib/metadata",
+      "weight": 7
+    },
+    {
+      "source": "api",
+      "target": "pages",
+      "weight": 6
+    },
+    {
+      "source": "build/output",
+      "target": "lib",
+      "weight": 6
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server/request",
+      "weight": 6
+    },
+    {
+      "source": "build/swc",
+      "target": "build",
+      "weight": 6
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "build",
+      "weight": 6
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "build/swc",
+      "weight": 6
+    },
+    {
+      "source": "build/webpack",
+      "target": "trace",
+      "weight": 6
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "build/webpack",
+      "weight": 6
+    },
+    {
+      "source": "cli",
+      "target": "build/output",
+      "weight": 6
+    },
+    {
+      "source": "cli",
+      "target": "trace",
+      "weight": 6
+    },
+    {
+      "source": "client/app-dir",
+      "target": "shared/lib",
+      "weight": 6
+    },
+    {
+      "source": "client",
+      "target": "client/react-client-callbacks",
+      "weight": 6
+    },
+    {
+      "source": "client/components",
+      "target": "server/request",
+      "weight": 6
+    },
+    {
+      "source": "client/dev",
+      "target": "next-devtools/userspace",
+      "weight": 6
+    },
+    {
+      "source": "export/routes",
+      "target": "shared/lib",
+      "weight": 6
+    },
+    {
+      "source": "lib/memory",
+      "target": "build/output",
+      "weight": 6
+    },
+    {
+      "source": "server",
+      "target": "server/api-utils",
+      "weight": 6
+    },
+    {
+      "source": "server/dev",
+      "target": "next-devtools/shared",
+      "weight": 6
+    },
+    {
+      "source": "server/dev",
+      "target": "next-devtools/dev-overlay",
+      "weight": 6
+    },
+    {
+      "source": "server/dev",
+      "target": "server/base-http",
+      "weight": 6
+    },
+    {
+      "source": "server/dev",
+      "target": "server/route-modules",
+      "weight": 6
+    },
+    {
+      "source": "server/lib",
+      "target": "server/web",
+      "weight": 6
+    },
+    {
+      "source": "server",
+      "target": "server/stream-utils",
+      "weight": 6
+    },
+    {
+      "source": "server/request",
+      "target": "client/components",
+      "weight": 6
+    },
+    {
+      "source": "server/route-definitions",
+      "target": "server",
+      "weight": 6
+    },
+    {
+      "source": "server/route-matchers",
+      "target": "server/route-definitions",
+      "weight": 6
+    },
+    {
+      "source": "server/route-matches",
+      "target": "server/route-definitions",
+      "weight": 6
+    },
+    {
+      "source": "server/use-cache",
+      "target": "server",
+      "weight": 6
+    },
+    {
+      "source": "server/web",
+      "target": "server/after",
+      "weight": 6
+    },
+    {
+      "source": "api",
+      "target": "client/components",
+      "weight": 5
+    },
+    {
+      "source": "bin",
+      "target": "lib",
+      "weight": 5
+    },
+    {
+      "source": "build/analysis",
+      "target": "shared/lib",
+      "weight": 5
+    },
+    {
+      "source": "build",
+      "target": "server/api-utils",
+      "weight": 5
+    },
+    {
+      "source": "build",
+      "target": "build/static-paths",
+      "weight": 5
+    },
+    {
+      "source": "build",
+      "target": "build/segment-config",
+      "weight": 5
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server/lib",
+      "weight": 5
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server/app-render",
+      "weight": 5
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server/route-modules",
+      "weight": 5
+    },
+    {
+      "source": "build/templates",
+      "target": "server/request",
+      "weight": 5
+    },
+    {
+      "source": "cli",
+      "target": "server",
+      "weight": 5
+    },
+    {
+      "source": "client/components",
+      "target": "lib",
+      "weight": 5
+    },
+    {
+      "source": "client/dev",
+      "target": "client/components",
+      "weight": 5
+    },
+    {
+      "source": "client/request",
+      "target": "shared/lib",
+      "weight": 5
+    },
+    {
+      "source": "experimental/testing",
+      "target": "lib",
+      "weight": 5
+    },
+    {
+      "source": "export",
+      "target": "build",
+      "weight": 5
+    },
+    {
+      "source": "export",
+      "target": "build/turborepo-access-trace",
+      "weight": 5
+    },
+    {
+      "source": "export/routes",
+      "target": "server/route-modules",
+      "weight": 5
+    },
+    {
+      "source": "lib/memory",
+      "target": "lib",
+      "weight": 5
+    },
+    {
+      "source": "lib/metadata",
+      "target": "server/app-render",
+      "weight": 5
+    },
+    {
+      "source": "lib",
+      "target": "lib/typescript",
+      "weight": 5
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "next-devtools/userspace",
+      "weight": 5
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "shared/lib",
+      "weight": 5
+    },
+    {
+      "source": "server/api-utils",
+      "target": "shared/lib",
+      "weight": 5
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/async-storage",
+      "weight": 5
+    },
+    {
+      "source": "server/app-render",
+      "target": "lib/framework",
+      "weight": 5
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/app-render",
+      "weight": 5
+    },
+    {
+      "source": "server",
+      "target": "build",
+      "weight": 5
+    },
+    {
+      "source": "server",
+      "target": "server/route-matches",
+      "weight": 5
+    },
+    {
+      "source": "server",
+      "target": "server/normalizers",
+      "weight": 5
+    },
+    {
+      "source": "server",
+      "target": "build/output",
+      "weight": 5
+    },
+    {
+      "source": "server",
+      "target": "server/route-matcher-providers",
+      "weight": 5
+    },
+    {
+      "source": "server/lib",
+      "target": "client/components",
+      "weight": 5
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "server",
+      "weight": 5
+    },
+    {
+      "source": "server/response-cache",
+      "target": "lib",
+      "weight": 5
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "server/route-definitions",
+      "weight": 5
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "server/route-matchers",
+      "weight": 5
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/route-definitions",
+      "weight": 5
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/api-utils",
+      "weight": 5
+    },
+    {
+      "source": "server/web",
+      "target": "build/webpack",
+      "weight": 5
+    },
+    {
+      "source": "(root)",
+      "target": "shared/lib",
+      "weight": 5
+    },
+    {
+      "source": "build",
+      "target": "telemetry",
+      "weight": 4
+    },
+    {
+      "source": "build/analyze",
+      "target": "build",
+      "weight": 4
+    },
+    {
+      "source": "build/static-paths",
+      "target": "lib",
+      "weight": 4
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "lib",
+      "weight": 4
+    },
+    {
+      "source": "build",
+      "target": "server/route-modules",
+      "weight": 4
+    },
+    {
+      "source": "cli",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "client/request",
+      "target": "server/request",
+      "weight": 4
+    },
+    {
+      "source": "experimental/testing",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "export/helpers",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "export",
+      "target": "export/helpers",
+      "weight": 4
+    },
+    {
+      "source": "export",
+      "target": "server/request",
+      "weight": 4
+    },
+    {
+      "source": "export/routes",
+      "target": "server/base-http",
+      "weight": 4
+    },
+    {
+      "source": "export",
+      "target": "server/lib",
+      "weight": 4
+    },
+    {
+      "source": "export",
+      "target": "export/routes",
+      "weight": 4
+    },
+    {
+      "source": "lib",
+      "target": "build",
+      "weight": 4
+    },
+    {
+      "source": "lib",
+      "target": "client/components",
+      "weight": 4
+    },
+    {
+      "source": "lib/metadata",
+      "target": "lib",
+      "weight": 4
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "server/dev",
+      "weight": 4
+    },
+    {
+      "source": "next-devtools/shared",
+      "target": "next-devtools/server",
+      "weight": 4
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "lib",
+      "weight": 4
+    },
+    {
+      "source": "server/after",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/api-utils",
+      "target": "server/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/api-utils",
+      "target": "(root)",
+      "weight": 4
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/use-cache",
+      "weight": 4
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/api-utils",
+      "weight": 4
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/base-http",
+      "target": "server/api-utils",
+      "weight": 4
+    },
+    {
+      "source": "server/base-http",
+      "target": "server/web",
+      "weight": 4
+    },
+    {
+      "source": "server",
+      "target": "server/request",
+      "weight": 4
+    },
+    {
+      "source": "server",
+      "target": "server/route-matcher-managers",
+      "weight": 4
+    },
+    {
+      "source": "server",
+      "target": "server/after",
+      "weight": 4
+    },
+    {
+      "source": "server/dev",
+      "target": "build/static-paths",
+      "weight": 4
+    },
+    {
+      "source": "server/lib",
+      "target": "build/webpack",
+      "weight": 4
+    },
+    {
+      "source": "server/mcp",
+      "target": "build/swc",
+      "weight": 4
+    },
+    {
+      "source": "server/mcp",
+      "target": "next-devtools/dev-overlay",
+      "weight": 4
+    },
+    {
+      "source": "server/mcp",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/request",
+      "target": "build/static-paths",
+      "weight": 4
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "lib/metadata",
+      "weight": 4
+    },
+    {
+      "source": "server/route-matchers",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/base-http",
+      "weight": 4
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/normalizers",
+      "weight": 4
+    },
+    {
+      "source": "server/stream-utils",
+      "target": "lib",
+      "weight": 4
+    },
+    {
+      "source": "server/stream-utils",
+      "target": "client/components",
+      "weight": 4
+    },
+    {
+      "source": "server/use-cache",
+      "target": "shared/lib",
+      "weight": 4
+    },
+    {
+      "source": "server/use-cache",
+      "target": "server/request",
+      "weight": 4
+    },
+    {
+      "source": "server/web",
+      "target": "server/response-cache",
+      "weight": 4
+    },
+    {
+      "source": "shared/lib",
+      "target": "build/output",
+      "weight": 4
+    },
+    {
+      "source": "shared/lib",
+      "target": "server/lib",
+      "weight": 4
+    },
+    {
+      "source": "shared/lib",
+      "target": "server/dev",
+      "weight": 4
+    },
+    {
+      "source": "telemetry",
+      "target": "lib",
+      "weight": 4
+    },
+    {
+      "source": "(root)",
+      "target": "client",
+      "weight": 4
+    },
+    {
+      "source": "api",
+      "target": "server/request",
+      "weight": 3
+    },
+    {
+      "source": "bin",
+      "target": "server/lib",
+      "weight": 3
+    },
+    {
+      "source": "build/analysis",
+      "target": "build",
+      "weight": 3
+    },
+    {
+      "source": "build/analyze",
+      "target": "lib",
+      "weight": 3
+    },
+    {
+      "source": "build/babel",
+      "target": "trace",
+      "weight": 3
+    },
+    {
+      "source": "build",
+      "target": "build/turborepo-access-trace",
+      "weight": 3
+    },
+    {
+      "source": "build",
+      "target": "diagnostics",
+      "weight": 3
+    },
+    {
+      "source": "build",
+      "target": "export",
+      "weight": 3
+    },
+    {
+      "source": "build/jest",
+      "target": "build/swc",
+      "weight": 3
+    },
+    {
+      "source": "build/output",
+      "target": "shared/lib",
+      "weight": 3
+    },
+    {
+      "source": "build/output",
+      "target": "trace",
+      "weight": 3
+    },
+    {
+      "source": "build/segment-config",
+      "target": "lib",
+      "weight": 3
+    },
+    {
+      "source": "build/static-paths",
+      "target": "build/segment-config",
+      "weight": 3
+    },
+    {
+      "source": "build/swc",
+      "target": "lib",
+      "weight": 3
+    },
+    {
+      "source": "build/templates",
+      "target": "server/instrumentation",
+      "weight": 3
+    },
+    {
+      "source": "build/templates",
+      "target": "server/api-utils",
+      "weight": 3
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "shared/lib",
+      "weight": 3
+    },
+    {
+      "source": "build/webpack",
+      "target": "server/normalizers",
+      "weight": 3
+    },
+    {
+      "source": "client/react-client-callbacks",
+      "target": "client/components",
+      "weight": 3
+    },
+    {
+      "source": "experimental/testing",
+      "target": "server",
+      "weight": 3
+    },
+    {
+      "source": "experimental/testing",
+      "target": "build",
+      "weight": 3
+    },
+    {
+      "source": "experimental/testing",
+      "target": "server/base-http",
+      "weight": 3
+    },
+    {
+      "source": "export",
+      "target": "build/webpack",
+      "weight": 3
+    },
+    {
+      "source": "export/routes",
+      "target": "export",
+      "weight": 3
+    },
+    {
+      "source": "export/routes",
+      "target": "server/app-render",
+      "weight": 3
+    },
+    {
+      "source": "export/routes",
+      "target": "server/request",
+      "weight": 3
+    },
+    {
+      "source": "export/routes",
+      "target": "server/web",
+      "weight": 3
+    },
+    {
+      "source": "export",
+      "target": "server/route-modules",
+      "weight": 3
+    },
+    {
+      "source": "lib/memory",
+      "target": "trace",
+      "weight": 3
+    },
+    {
+      "source": "lib/metadata",
+      "target": "lib/framework",
+      "weight": 3
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "lib",
+      "weight": 3
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "server/lib",
+      "weight": 3
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "client/lib",
+      "weight": 3
+    },
+    {
+      "source": "server/after",
+      "target": "lib",
+      "weight": 3
+    },
+    {
+      "source": "server/api-utils",
+      "target": "server/web",
+      "weight": 3
+    },
+    {
+      "source": "server/app-render",
+      "target": "(root)",
+      "weight": 3
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/route-modules",
+      "weight": 3
+    },
+    {
+      "source": "server/app-render",
+      "target": "build/output",
+      "weight": 3
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/node-environment-extensions",
+      "weight": 3
+    },
+    {
+      "source": "server/app-render",
+      "target": "lib/metadata",
+      "weight": 3
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/instrumentation",
+      "weight": 3
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/base-http",
+      "weight": 3
+    },
+    {
+      "source": "server/async-storage",
+      "target": "client/components",
+      "weight": 3
+    },
+    {
+      "source": "server/base-http",
+      "target": "server",
+      "weight": 3
+    },
+    {
+      "source": "server/dev",
+      "target": "server/stream-utils",
+      "weight": 3
+    },
+    {
+      "source": "server/dev",
+      "target": "build/webpack",
+      "weight": 3
+    },
+    {
+      "source": "server/dev",
+      "target": "server/route-matcher-managers",
+      "weight": 3
+    },
+    {
+      "source": "server/dev",
+      "target": "server/use-cache",
+      "weight": 3
+    },
+    {
+      "source": "server/lib",
+      "target": "server/base-http",
+      "weight": 3
+    },
+    {
+      "source": "server/lib",
+      "target": "server/normalizers",
+      "weight": 3
+    },
+    {
+      "source": "server",
+      "target": "server/use-cache",
+      "weight": 3
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "shared/lib",
+      "weight": 3
+    },
+    {
+      "source": "server/response-cache",
+      "target": "server/lib",
+      "weight": 3
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "server",
+      "weight": 3
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "server/route-matcher-providers",
+      "weight": 3
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "server/route-matches",
+      "weight": 3
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "server/lib",
+      "weight": 3
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/async-storage",
+      "weight": 3
+    },
+    {
+      "source": "server/route-modules",
+      "target": "pages",
+      "weight": 3
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/instrumentation",
+      "weight": 3
+    },
+    {
+      "source": "shared/lib",
+      "target": "client/components",
+      "weight": 3
+    },
+    {
+      "source": "shared/lib",
+      "target": "(root)",
+      "weight": 3
+    },
+    {
+      "source": "shared/lib",
+      "target": "server/app-render",
+      "weight": 3
+    },
+    {
+      "source": "shared/lib",
+      "target": "trace",
+      "weight": 3
+    },
+    {
+      "source": "telemetry",
+      "target": "server",
+      "weight": 3
+    },
+    {
+      "source": "telemetry/events",
+      "target": "build/webpack",
+      "weight": 3
+    },
+    {
+      "source": "build/adapter",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "build/adapter",
+      "target": "build/webpack",
+      "weight": 2
+    },
+    {
+      "source": "build/adapter",
+      "target": "lib/metadata",
+      "weight": 2
+    },
+    {
+      "source": "build/analysis",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "build/analyze",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "build/analyze",
+      "target": "trace",
+      "weight": 2
+    },
+    {
+      "source": "build/analyze",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "build/analyze",
+      "target": "build/turbopack-analyze",
+      "weight": 2
+    },
+    {
+      "source": "build/babel",
+      "target": "build/swc",
+      "weight": 2
+    },
+    {
+      "source": "build/babel",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "build",
+      "target": "(root)",
+      "weight": 2
+    },
+    {
+      "source": "build/next-config-ts",
+      "target": "build/output",
+      "weight": 2
+    },
+    {
+      "source": "build/output",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "build/segment-config",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "build/templates",
+      "target": "server/stream-utils",
+      "weight": 2
+    },
+    {
+      "source": "build/templates",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "lib",
+      "weight": 2
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "build/swc",
+      "weight": 2
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "telemetry",
+      "weight": 2
+    },
+    {
+      "source": "build/webpack",
+      "target": "client/components",
+      "weight": 2
+    },
+    {
+      "source": "build/webpack",
+      "target": "(root)",
+      "weight": 2
+    },
+    {
+      "source": "build/webpack",
+      "target": "client",
+      "weight": 2
+    },
+    {
+      "source": "build/webpack",
+      "target": "server/web",
+      "weight": 2
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "build/output",
+      "weight": 2
+    },
+    {
+      "source": "build/webpack-config-rules",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "build",
+      "target": "build/webpack-config-rules",
+      "weight": 2
+    },
+    {
+      "source": "cli/internal",
+      "target": "build/swc",
+      "weight": 2
+    },
+    {
+      "source": "cli",
+      "target": "build",
+      "weight": 2
+    },
+    {
+      "source": "cli",
+      "target": "lib/memory",
+      "weight": 2
+    },
+    {
+      "source": "cli",
+      "target": "telemetry",
+      "weight": 2
+    },
+    {
+      "source": "cli",
+      "target": "build/swc",
+      "weight": 2
+    },
+    {
+      "source": "client",
+      "target": "build/polyfills",
+      "weight": 2
+    },
+    {
+      "source": "client/components",
+      "target": "client/lib",
+      "weight": 2
+    },
+    {
+      "source": "client/dev",
+      "target": "client",
+      "weight": 2
+    },
+    {
+      "source": "client/dev",
+      "target": "lib",
+      "weight": 2
+    },
+    {
+      "source": "client/legacy",
+      "target": "client",
+      "weight": 2
+    },
+    {
+      "source": "client",
+      "target": "server/dev",
+      "weight": 2
+    },
+    {
+      "source": "client",
+      "target": "build/analysis",
+      "weight": 2
+    },
+    {
+      "source": "client",
+      "target": "client/lib",
+      "weight": 2
+    },
+    {
+      "source": "client/react-client-callbacks",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "client/request",
+      "target": "server/web",
+      "weight": 2
+    },
+    {
+      "source": "client/tracing",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "diagnostics",
+      "target": "trace",
+      "weight": 2
+    },
+    {
+      "source": "experimental/testing",
+      "target": "server/web",
+      "weight": 2
+    },
+    {
+      "source": "export/helpers",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "export/helpers",
+      "target": "lib",
+      "weight": 2
+    },
+    {
+      "source": "export/helpers",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "export/helpers",
+      "target": "client/components",
+      "weight": 2
+    },
+    {
+      "source": "export",
+      "target": "trace",
+      "weight": 2
+    },
+    {
+      "source": "export/routes",
+      "target": "export/helpers",
+      "weight": 2
+    },
+    {
+      "source": "export/routes",
+      "target": "server/after",
+      "weight": 2
+    },
+    {
+      "source": "export",
+      "target": "server/app-render",
+      "weight": 2
+    },
+    {
+      "source": "export",
+      "target": "server/resume-data-cache",
+      "weight": 2
+    },
+    {
+      "source": "lib",
+      "target": "(root)",
+      "weight": 2
+    },
+    {
+      "source": "lib/metadata",
+      "target": "build/webpack",
+      "weight": 2
+    },
+    {
+      "source": "lib/metadata",
+      "target": "build/output",
+      "weight": 2
+    },
+    {
+      "source": "lib/metadata",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "lib/typescript",
+      "target": "build/output",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools",
+      "target": "next-devtools/shared",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools",
+      "target": "server/dev",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "build/output",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "next-devtools/shared",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "telemetry",
+      "weight": 2
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "client/dev",
+      "weight": 2
+    },
+    {
+      "source": "pages",
+      "target": "client",
+      "weight": 2
+    },
+    {
+      "source": "pages",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "pages",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "server/after",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "server/api-utils",
+      "target": "server/base-http",
+      "weight": 2
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/response-cache",
+      "weight": 2
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/request",
+      "weight": 2
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "server",
+      "target": "build/static-paths",
+      "weight": 2
+    },
+    {
+      "source": "server",
+      "target": "cli",
+      "weight": 2
+    },
+    {
+      "source": "server",
+      "target": "build/swc",
+      "weight": 2
+    },
+    {
+      "source": "server/dev",
+      "target": "server/api-utils",
+      "weight": 2
+    },
+    {
+      "source": "server/dev",
+      "target": "lib/metadata",
+      "weight": 2
+    },
+    {
+      "source": "server/dev",
+      "target": "telemetry",
+      "weight": 2
+    },
+    {
+      "source": "server/dev",
+      "target": "next-devtools/userspace",
+      "weight": 2
+    },
+    {
+      "source": "server/dev",
+      "target": "build/segment-config",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "telemetry",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "server/request",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "(root)",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "server/instrumentation",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "build/swc",
+      "weight": 2
+    },
+    {
+      "source": "server/lib",
+      "target": "telemetry/events",
+      "weight": 2
+    },
+    {
+      "source": "server/mcp",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "server/mcp",
+      "target": "next-devtools/server",
+      "weight": 2
+    },
+    {
+      "source": "server",
+      "target": "next-devtools/userspace",
+      "weight": 2
+    },
+    {
+      "source": "server/request",
+      "target": "server/route-modules",
+      "weight": 2
+    },
+    {
+      "source": "server/resume-data-cache",
+      "target": "server/app-render",
+      "weight": 2
+    },
+    {
+      "source": "server/resume-data-cache",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "lib",
+      "weight": 2
+    },
+    {
+      "source": "server/route-matchers",
+      "target": "server/route-matches",
+      "weight": 2
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/request",
+      "weight": 2
+    },
+    {
+      "source": "server/route-modules",
+      "target": "build/segment-config",
+      "weight": 2
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "server/stream-utils",
+      "target": "server/lib",
+      "weight": 2
+    },
+    {
+      "source": "server/stream-utils",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "server/use-cache",
+      "target": "lib",
+      "weight": 2
+    },
+    {
+      "source": "server/use-cache",
+      "target": "client/components",
+      "weight": 2
+    },
+    {
+      "source": "server/use-cache",
+      "target": "server/web",
+      "weight": 2
+    },
+    {
+      "source": "server/web",
+      "target": "server/async-storage",
+      "weight": 2
+    },
+    {
+      "source": "server/web",
+      "target": "server/route-modules",
+      "weight": 2
+    },
+    {
+      "source": "server/web",
+      "target": "server/use-cache",
+      "weight": 2
+    },
+    {
+      "source": "server/web",
+      "target": "server/instrumentation",
+      "weight": 2
+    },
+    {
+      "source": "server/web",
+      "target": "build/segment-config",
+      "weight": 2
+    },
+    {
+      "source": "shared/lib",
+      "target": "server/api-utils",
+      "weight": 2
+    },
+    {
+      "source": "shared/lib",
+      "target": "next-devtools/dev-overlay",
+      "weight": 2
+    },
+    {
+      "source": "shared/lib",
+      "target": "server/base-http",
+      "weight": 2
+    },
+    {
+      "source": "telemetry/events",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "trace/report",
+      "target": "shared/lib",
+      "weight": 2
+    },
+    {
+      "source": "trace",
+      "target": "lib/helpers",
+      "weight": 2
+    },
+    {
+      "source": "(root)",
+      "target": "server",
+      "weight": 2
+    },
+    {
+      "source": "(root)",
+      "target": "build/adapter",
+      "weight": 2
+    },
+    {
+      "source": "api",
+      "target": "server/og",
+      "weight": 1
+    },
+    {
+      "source": "api",
+      "target": "server/web",
+      "weight": 1
+    },
+    {
+      "source": "bin",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "bin",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/adapter",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/adapter",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "build/analysis",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "build/analysis",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/analysis",
+      "target": "build/webpack",
+      "weight": 1
+    },
+    {
+      "source": "build/analysis",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "build/analyze",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "build/analyze",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/analyze",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "build/analyze",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "build/analyze",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "build/babel",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/babel",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "build/babel",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "build/babel",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "build/webpack-build",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "build/manifests",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "lib/memory",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "server/app-render",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "build/turbopack-build",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "build/adapter",
+      "weight": 1
+    },
+    {
+      "source": "build/jest",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "build/jest",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "build/jest",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "build/jest",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/jest",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "lib/typescript",
+      "weight": 1
+    },
+    {
+      "source": "build/next-config-ts",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "server/normalizers",
+      "weight": 1
+    },
+    {
+      "source": "build/output",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "build/segment-config",
+      "target": "server/request",
+      "weight": 1
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server/after",
+      "weight": 1
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server/async-storage",
+      "weight": 1
+    },
+    {
+      "source": "build/static-paths",
+      "target": "export/helpers",
+      "weight": 1
+    },
+    {
+      "source": "build/static-paths",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "build/static-paths",
+      "target": "(root)",
+      "weight": 1
+    },
+    {
+      "source": "build/swc",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/swc",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "build/swc",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "build/templates",
+      "target": "build/static-paths",
+      "weight": 1
+    },
+    {
+      "source": "build/templates",
+      "target": "build/adapter",
+      "weight": 1
+    },
+    {
+      "source": "build/templates",
+      "target": "(root)",
+      "weight": 1
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "build/turbopack-analyze",
+      "target": "trace",
+      "weight": 1
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "export",
+      "weight": 1
+    },
+    {
+      "source": "build/turbopack-build",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "server/web",
+      "weight": 1
+    },
+    {
+      "source": "build",
+      "target": "export/helpers",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack",
+      "target": "server/route-modules",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack",
+      "target": "server/use-cache",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack",
+      "target": "server/app-render",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "build/webpack-build",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "cli/internal",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "cli/internal",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "cli",
+      "target": "build/analyze",
+      "weight": 1
+    },
+    {
+      "source": "cli",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "cli",
+      "target": "server/dev",
+      "weight": 1
+    },
+    {
+      "source": "cli",
+      "target": "next-devtools/shared",
+      "weight": 1
+    },
+    {
+      "source": "client",
+      "target": "next-devtools/userspace",
+      "weight": 1
+    },
+    {
+      "source": "client/compat",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "client/compat",
+      "target": "client",
+      "weight": 1
+    },
+    {
+      "source": "client/components",
+      "target": "lib/framework",
+      "weight": 1
+    },
+    {
+      "source": "client/components",
+      "target": "client/dev",
+      "weight": 1
+    },
+    {
+      "source": "client/components",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "client/components",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "client/dev",
+      "target": "next-devtools/shared",
+      "weight": 1
+    },
+    {
+      "source": "client/dev",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "client",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "client",
+      "target": "client/portal",
+      "weight": 1
+    },
+    {
+      "source": "client",
+      "target": "client/tracing",
+      "weight": 1
+    },
+    {
+      "source": "client/lib",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "client/lib",
+      "target": "client",
+      "weight": 1
+    },
+    {
+      "source": "client/react-client-callbacks",
+      "target": "next-devtools/userspace",
+      "weight": 1
+    },
+    {
+      "source": "client/react-client-callbacks",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "client",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "client/tracing",
+      "target": "client/dev",
+      "weight": 1
+    },
+    {
+      "source": "diagnostics",
+      "target": "export",
+      "weight": 1
+    },
+    {
+      "source": "diagnostics",
+      "target": "server/base-http",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testing",
+      "target": "server/request",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testing",
+      "target": "server/route-modules",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testing",
+      "target": "build/analysis",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testing",
+      "target": "build/segment-config",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testing",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testmode",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "experimental/testmode",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "export/helpers",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "export/helpers",
+      "target": "server/app-render",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "build/manifests",
+      "weight": 1
+    },
+    {
+      "source": "export/routes",
+      "target": "client/components",
+      "weight": 1
+    },
+    {
+      "source": "export/routes",
+      "target": "server/resume-data-cache",
+      "weight": 1
+    },
+    {
+      "source": "export/routes",
+      "target": "lib/metadata",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "server/base-http",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "client/components",
+      "weight": 1
+    },
+    {
+      "source": "export",
+      "target": "server/node-environment-extensions",
+      "weight": 1
+    },
+    {
+      "source": "lib/helpers",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "lib/helpers",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "lib/metadata",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "lib/metadata",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "lib/metadata",
+      "target": "client/components",
+      "weight": 1
+    },
+    {
+      "source": "lib/typescript",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "lib/typescript",
+      "target": "lib/helpers",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/dev-overlay",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools",
+      "target": "next-devtools/userspace",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "server/dev",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "next-devtools/dev-overlay",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "build/webpack",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/server",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/shared",
+      "target": "next-devtools/dev-overlay",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/shared",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/shared",
+      "target": "server/dev",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "client",
+      "weight": 1
+    },
+    {
+      "source": "next-devtools/userspace",
+      "target": "client/react-client-callbacks",
+      "weight": 1
+    },
+    {
+      "source": "pages",
+      "target": "build/webpack",
+      "weight": 1
+    },
+    {
+      "source": "pages",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "server/after",
+      "target": "server/web",
+      "weight": 1
+    },
+    {
+      "source": "server/api-utils",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "server/api-utils",
+      "target": "server/instrumentation",
+      "weight": 1
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/dev",
+      "weight": 1
+    },
+    {
+      "source": "server/app-render",
+      "target": "build/swc",
+      "weight": 1
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "server/app-render",
+      "target": "next-devtools/dev-overlay",
+      "weight": 1
+    },
+    {
+      "source": "server/app-render",
+      "target": "server/after",
+      "weight": 1
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/response-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/resume-data-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/async-storage",
+      "target": "build/segment-config",
+      "weight": 1
+    },
+    {
+      "source": "server/async-storage",
+      "target": "server/after",
+      "weight": 1
+    },
+    {
+      "source": "server/async-storage",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/base-http",
+      "target": "client/components",
+      "weight": 1
+    },
+    {
+      "source": "server/base-http",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "server/base-http",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "build/analysis",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "server/instrumentation",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "api",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "build/next-config-ts",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "build/adapter",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "server/mcp",
+      "weight": 1
+    },
+    {
+      "source": "server/dev",
+      "target": "server/request",
+      "weight": 1
+    },
+    {
+      "source": "server/dev",
+      "target": "server/response-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/dev",
+      "target": "client",
+      "weight": 1
+    },
+    {
+      "source": "server/dev",
+      "target": "export/helpers",
+      "weight": 1
+    },
+    {
+      "source": "server/dev",
+      "target": "server/after",
+      "weight": 1
+    },
+    {
+      "source": "server/dev",
+      "target": "server/async-storage",
+      "weight": 1
+    },
+    {
+      "source": "server/lib",
+      "target": "export/routes",
+      "weight": 1
+    },
+    {
+      "source": "server/lib",
+      "target": "server/route-modules",
+      "weight": 1
+    },
+    {
+      "source": "server/lib",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "server/lib",
+      "target": "next-devtools/dev-overlay",
+      "weight": 1
+    },
+    {
+      "source": "server/lib",
+      "target": "build/analysis",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "lib/metadata",
+      "weight": 1
+    },
+    {
+      "source": "server/mcp",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "server/mcp",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "server/mcp",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "server/typescript",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "server/dev",
+      "weight": 1
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "server/dev",
+      "weight": 1
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "client/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/node-environment-extensions",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/normalizers",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "next-devtools/server",
+      "weight": 1
+    },
+    {
+      "source": "server",
+      "target": "server/resume-data-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/request",
+      "target": "server/async-storage",
+      "weight": 1
+    },
+    {
+      "source": "server/request",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/response-cache",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "server/resume-data-cache",
+      "target": "server/response-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/resume-data-cache",
+      "target": "server/stream-utils",
+      "weight": 1
+    },
+    {
+      "source": "server/resume-data-cache",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matcher-managers",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matcher-providers",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matchers",
+      "target": "server/lib",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matchers",
+      "target": "server/request",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matches",
+      "target": "server",
+      "weight": 1
+    },
+    {
+      "source": "server/route-matches",
+      "target": "server/request",
+      "weight": 1
+    },
+    {
+      "source": "server/route-modules",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "server/route-modules",
+      "target": "server/resume-data-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/route-modules",
+      "target": "build/adapter",
+      "weight": 1
+    },
+    {
+      "source": "server/route-modules",
+      "target": "build/webpack",
+      "weight": 1
+    },
+    {
+      "source": "server/route-modules",
+      "target": "lib/metadata",
+      "weight": 1
+    },
+    {
+      "source": "server/stream-utils",
+      "target": "server/app-render",
+      "weight": 1
+    },
+    {
+      "source": "server/typescript",
+      "target": "build/segment-config",
+      "weight": 1
+    },
+    {
+      "source": "server/use-cache",
+      "target": "build/webpack",
+      "weight": 1
+    },
+    {
+      "source": "server/use-cache",
+      "target": "server/resume-data-cache",
+      "weight": 1
+    },
+    {
+      "source": "server/use-cache",
+      "target": "build/output",
+      "weight": 1
+    },
+    {
+      "source": "server/web",
+      "target": "server/route-matchers",
+      "weight": 1
+    },
+    {
+      "source": "server/web",
+      "target": "server/request",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "lib/metadata",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "client/lib",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "build/analysis",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "lib/memory",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "telemetry/events",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "lib/fs",
+      "weight": 1
+    },
+    {
+      "source": "shared/lib",
+      "target": "build",
+      "weight": 1
+    },
+    {
+      "source": "telemetry",
+      "target": "shared/lib",
+      "weight": 1
+    },
+    {
+      "source": "telemetry/events",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "telemetry/events",
+      "target": "trace",
+      "weight": 1
+    },
+    {
+      "source": "telemetry/events",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "telemetry",
+      "target": "trace",
+      "weight": 1
+    },
+    {
+      "source": "trace/report",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "trace",
+      "target": "trace/report",
+      "weight": 1
+    },
+    {
+      "source": "trace",
+      "target": "telemetry",
+      "weight": 1
+    },
+    {
+      "source": "(root)",
+      "target": "lib",
+      "weight": 1
+    },
+    {
+      "source": "(root)",
+      "target": "server/api-utils",
+      "weight": 1
+    },
+    {
+      "source": "(root)",
+      "target": "build/segment-config",
+      "weight": 1
+    },
+    {
+      "source": "(root)",
+      "target": "server/instrumentation",
+      "weight": 1
+    }
+  ]
+}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,4505 +1,4554 @@
 {
-  "name": "graph-sitter-site",
-  "version": "0.1.0",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "graph-sitter-site",
-      "version": "0.1.0",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.3.0",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "github-slugger": "^2.0.0",
-        "gray-matter": "^4.0.3",
-        "lucide-react": "1.21.0",
-        "next": "16.2.9",
-        "next-mdx-remote": "^5.0.0",
-        "next-themes": "^0.4.6",
-        "react": "19.2.7",
-        "react-dom": "19.2.7",
-        "rehype-autolink-headings": "^7.1.0",
-        "rehype-pretty-code": "^0.14.3",
-        "rehype-slug": "^6.0.0",
-        "remark-gfm": "^4.0.0",
-        "tailwind-merge": "^3.6.0",
-        "tw-animate-css": "^1.4.0"
-      },
-      "devDependencies": {
-        "@tailwindcss/postcss": "^4.3.1",
-        "@types/node": "26.0.0",
-        "@types/react": "19.2.17",
-        "@types/react-dom": "19.2.3",
-        "tailwindcss": "^4.3.1",
-        "typescript": "6.0.3"
-      }
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mdx-js/mdx": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
-      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "@types/estree-jsx": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "@types/mdx": "^2.0.0",
-        "acorn": "^8.0.0",
-        "collapse-white-space": "^2.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-is-identifier-name": "^3.0.0",
-        "estree-util-scope": "^1.0.0",
-        "estree-walker": "^3.0.0",
-        "hast-util-to-jsx-runtime": "^2.0.0",
-        "markdown-extensions": "^2.0.0",
-        "recma-build-jsx": "^1.0.0",
-        "recma-jsx": "^1.0.0",
-        "recma-stringify": "^1.0.0",
-        "rehype-recma": "^1.0.0",
-        "remark-mdx": "^3.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.0.0",
-        "source-map": "^0.7.0",
-        "unified": "^11.0.0",
-        "unist-util-position-from-estree": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@mdx-js/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdx": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16",
-        "react": ">=16"
-      }
-    },
-    "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
-      "license": "MIT"
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
-      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
-      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@shikijs/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/primitive": "4.2.0",
-        "@shikijs/types": "4.2.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
-      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "4.2.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.6"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
-      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "4.2.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
-      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "4.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/primitive": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
-      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "4.2.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
-      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "4.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
-        "jiti": "^2.7.0",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-x64": "4.3.1",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
-      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
-      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
-      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
-      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
-      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
-      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
-      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
-      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
-      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
-        "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.2",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
-      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
-      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
-      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.1",
-        "@tailwindcss/oxide": "4.3.1",
-        "postcss": "8.5.15",
-        "tailwindcss": "4.3.1"
-      }
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/estree-jsx": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
-      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/mdx": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
-      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
-      "license": "ISC"
-    },
-    "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/astring": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
-      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
-      "license": "MIT",
-      "bin": {
-        "astring": "bin/astring"
-      }
-    },
-    "node_modules/bail": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-reference-invalid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/class-variance-authority": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
-      }
-    },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT"
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/collapse-white-space": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
-      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/esast-util-from-estree": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
-      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-visit": "^2.0.0",
-        "unist-util-position-from-estree": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/esast-util-from-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
-      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "acorn": "^8.0.0",
-        "esast-util-from-estree": "^2.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estree-util-attach-comments": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
-      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-util-build-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
-      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-is-identifier-name": "^3.0.0",
-        "estree-walker": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-util-is-identifier-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
-      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-util-scope": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
-      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "devlop": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-util-to-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
-      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "astring": "^1.8.0",
-        "source-map": "^0.7.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-util-visit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
-      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-heading-rank": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
-      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-estree": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
-      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "@types/estree-jsx": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-attach-comments": "^3.0.0",
-        "estree-util-is-identifier-name": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "mdast-util-mdx-expression": "^2.0.0",
-        "mdast-util-mdx-jsx": "^3.0.0",
-        "mdast-util-mdxjs-esm": "^2.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "style-to-js": "^1.0.0",
-        "unist-util-position": "^5.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-jsx-runtime": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
-      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-is-identifier-name": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "mdast-util-mdx-expression": "^2.0.0",
-        "mdast-util-mdx-jsx": "^3.0.0",
-        "mdast-util-mdxjs-esm": "^2.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "style-to-js": "^1.0.0",
-        "unist-util-position": "^5.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-string": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
-      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/inline-style-parser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-      "license": "MIT"
-    },
-    "node_modules/is-alphabetical": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^2.0.0",
-        "is-decimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-decimal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-hexadecimal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/markdown-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
-      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
-      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-mdx-expression": "^2.0.0",
-        "mdast-util-mdx-jsx": "^3.0.0",
-        "mdast-util-mdxjs-esm": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-expression": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
-      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdx-jsx": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
-      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "parse-entities": "^4.0.0",
-        "stringify-entities": "^4.0.0",
-        "unist-util-stringify-position": "^4.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
-      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "unist-util-visit": "^5.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-destination": "^2.0.0",
-        "micromark-factory-label": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-title": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-html-tag-name": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-mdx-expression": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
-      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-mdx-expression": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-events-to-acorn": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-mdx-jsx": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
-      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-is-identifier-name": "^3.0.0",
-        "micromark-factory-mdx-expression": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-events-to-acorn": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-mdx-md": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
-      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-mdxjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
-      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.0.0",
-        "acorn-jsx": "^5.0.0",
-        "micromark-extension-mdx-expression": "^3.0.0",
-        "micromark-extension-mdx-jsx": "^3.0.0",
-        "micromark-extension-mdx-md": "^2.0.0",
-        "micromark-extension-mdxjs-esm": "^3.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-mdxjs-esm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
-      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-events-to-acorn": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-position-from-estree": "^2.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-mdx-expression": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
-      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-events-to-acorn": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-position-from-estree": "^2.0.0",
-        "vfile-message": "^4.0.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-events-to-acorn": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
-      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "estree-util-visit": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "vfile-message": "^4.0.0"
-      }
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
-      "license": "MIT",
-      "dependencies": {
-        "@next/env": "16.2.9",
-        "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.9.19",
-        "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
-        "styled-jsx": "5.1.6"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
-        "sharp": "^0.34.5"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.51.1",
-        "babel-plugin-react-compiler": "*",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next-mdx-remote": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",
-      "integrity": "sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@mdx-js/mdx": "^3.0.1",
-        "@mdx-js/react": "^3.0.1",
-        "unist-util-remove": "^3.1.0",
-        "vfile": "^6.0.1",
-        "vfile-matter": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/oniguruma-parser": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
-      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/oniguruma-to-es": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
-      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "oniguruma-parser": "^0.12.2",
-        "regex": "^6.1.0",
-        "regex-recursion": "^6.0.2"
-      }
-    },
-    "node_modules/parse-entities": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
-      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "character-entities-legacy": "^3.0.0",
-        "character-reference-invalid": "^2.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "is-alphanumerical": "^2.0.0",
-        "is-decimal": "^2.0.0",
-        "is-hexadecimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/parse-entities/node_modules/@types/unist": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT"
-    },
-    "node_modules/parse-numeric-range": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
-      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
-      "license": "ISC"
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
-    },
-    "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/property-information": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
-      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/recma-build-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
-      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-util-build-jsx": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/recma-jsx": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
-      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn-jsx": "^5.0.0",
-        "estree-util-to-js": "^2.0.0",
-        "recma-parse": "^1.0.0",
-        "recma-stringify": "^1.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/recma-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
-      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "esast-util-from-js": "^2.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/recma-stringify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
-      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-util-to-js": "^2.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
-      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-recursion": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/rehype-autolink-headings": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
-      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-heading-rank": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-pretty-code": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.3.tgz",
-      "integrity": "sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.4",
-        "hast-util-to-string": "^3.0.0",
-        "parse-numeric-range": "^1.3.0",
-        "rehype-parse": "^9.0.0",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/rehype-recma": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
-      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "@types/hast": "^3.0.0",
-        "hast-util-to-estree": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-slug": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
-      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-heading-rank": "^3.0.0",
-        "hast-util-to-string": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-gfm": "^3.0.0",
-        "micromark-extension-gfm": "^3.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-mdx": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
-      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-mdx": "^3.0.0",
-        "micromark-extension-mdxjs": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-parse": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
-      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/core": "4.2.0",
-        "@shikijs/engine-javascript": "4.2.0",
-        "@shikijs/engine-oniguruma": "4.2.0",
-        "@shikijs/langs": "4.2.0",
-        "@shikijs/themes": "4.2.0",
-        "@shikijs/types": "4.2.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/style-to-js": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
-      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "style-to-object": "1.0.14"
-      }
-    },
-    "node_modules/style-to-object": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-      "license": "MIT",
-      "dependencies": {
-        "inline-style-parser": "0.2.7"
-      }
-    },
-    "node_modules/styled-jsx": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
-      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-      "license": "MIT",
-      "dependencies": {
-        "client-only": "0.0.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
-      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trough": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
-      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/tw-animate-css": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Wombosvideo"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unified": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "bail": "^2.0.0",
-        "devlop": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position-from-estree": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
-      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.1.tgz",
-      "integrity": "sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove/node_modules/@types/unist": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT"
-    },
-    "node_modules/unist-util-remove/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove/node_modules/unist-util-visit-parents": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-matter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
-      "integrity": "sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==",
-      "license": "MIT",
-      "dependencies": {
-        "vfile": "^6.0.0",
-        "yaml": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
-      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    }
-  }
+	"name": "graph-sitter-site",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "graph-sitter-site",
+			"version": "0.1.0",
+			"dependencies": {
+				"@radix-ui/react-slot": "^1.3.0",
+				"@types/d3-force": "^3.0.10",
+				"class-variance-authority": "^0.7.1",
+				"clsx": "^2.1.1",
+				"d3-force": "^3.0.0",
+				"github-slugger": "^2.0.0",
+				"gray-matter": "^4.0.3",
+				"lucide-react": "1.21.0",
+				"next": "16.2.9",
+				"next-mdx-remote": "^5.0.0",
+				"next-themes": "^0.4.6",
+				"react": "19.2.7",
+				"react-dom": "19.2.7",
+				"rehype-autolink-headings": "^7.1.0",
+				"rehype-pretty-code": "^0.14.3",
+				"rehype-slug": "^6.0.0",
+				"remark-gfm": "^4.0.0",
+				"tailwind-merge": "^3.6.0",
+				"tw-animate-css": "^1.4.0"
+			},
+			"devDependencies": {
+				"@tailwindcss/postcss": "^4.3.1",
+				"@types/node": "26.0.0",
+				"@types/react": "19.2.17",
+				"@types/react-dom": "19.2.3",
+				"tailwindcss": "^4.3.1",
+				"typescript": "6.0.3"
+			}
+		},
+		"node_modules/@alloc/quick-lru": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@img/colour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+			"integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+			"integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+			"integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+			"integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+			"integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+			"cpu": [
+				"arm"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+			"integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+			"integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+			"cpu": [
+				"s390x"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+			"integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+			"integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+			"cpu": [
+				"arm"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+			"integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+			"integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+			"cpu": [
+				"s390x"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+			"integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+			"integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.7.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+			"integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+			"integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+			"integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@mdx-js/mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+			"integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdx": "^2.0.0",
+				"acorn": "^8.0.0",
+				"collapse-white-space": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-util-scope": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"markdown-extensions": "^2.0.0",
+				"recma-build-jsx": "^1.0.0",
+				"recma-jsx": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"rehype-recma": "^1.0.0",
+				"remark-mdx": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"source-map": "^0.7.0",
+				"unified": "^11.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@mdx-js/react": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdx": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16",
+				"react": ">=16"
+			}
+		},
+		"node_modules/@next/env": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+			"integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+			"license": "MIT"
+		},
+		"node_modules/@next/swc-darwin-arm64": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+			"integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-darwin-x64": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+			"integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-arm64-gnu": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+			"integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-arm64-musl": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+			"integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-x64-gnu": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+			"integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-linux-x64-musl": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+			"integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-arm64-msvc": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+			"integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@next/swc-win32-x64-msvc": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+			"integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+			"integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+			"integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@shikijs/core": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+			"integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/primitive": "4.2.0",
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+			"integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.6"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+			"integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+			"integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/primitive": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+			"integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+			"integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "4.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@swc/helpers": {
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+			"integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@tailwindcss/node": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+			"integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/remapping": "^2.3.5",
+				"enhanced-resolve": "5.21.6",
+				"jiti": "^2.7.0",
+				"lightningcss": "1.32.0",
+				"magic-string": "^0.30.21",
+				"source-map-js": "^1.2.1",
+				"tailwindcss": "4.3.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+			"integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			},
+			"optionalDependencies": {
+				"@tailwindcss/oxide-android-arm64": "4.3.1",
+				"@tailwindcss/oxide-darwin-arm64": "4.3.1",
+				"@tailwindcss/oxide-darwin-x64": "4.3.1",
+				"@tailwindcss/oxide-freebsd-x64": "4.3.1",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+				"@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+				"@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-android-arm64": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+			"integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-darwin-arm64": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+			"integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-darwin-x64": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+			"integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-freebsd-x64": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+			"integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+			"integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+			"integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+			"integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+			"integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+			"integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+			"integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+			"bundleDependencies": [
+				"@napi-rs/wasm-runtime",
+				"@emnapi/core",
+				"@emnapi/runtime",
+				"@tybys/wasm-util",
+				"@emnapi/wasi-threads",
+				"tslib"
+			],
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.10.0",
+				"@emnapi/runtime": "^1.10.0",
+				"@emnapi/wasi-threads": "^1.2.1",
+				"@napi-rs/wasm-runtime": "^1.1.4",
+				"@tybys/wasm-util": "^0.10.2",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+			"integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+			"integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@tailwindcss/postcss": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
+			"integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@alloc/quick-lru": "^5.2.0",
+				"@tailwindcss/node": "4.3.1",
+				"@tailwindcss/oxide": "4.3.1",
+				"postcss": "8.5.15",
+				"tailwindcss": "4.3.1"
+			}
+		},
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/estree-jsx": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdx": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+			"integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+			"integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/@types/react": {
+			"version": "19.2.17",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+			"integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "19.2.3",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^19.2.0"
+			}
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+			"license": "ISC"
+		},
+		"node_modules/acorn": {
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/astring": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+			"integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+			"license": "MIT",
+			"bin": {
+				"astring": "bin/astring"
+			}
+		},
+		"node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.38",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+			"integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/class-variance-authority": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+			"integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"clsx": "^2.1.1"
+			},
+			"funding": {
+				"url": "https://polar.sh/cva"
+			}
+		},
+		"node_modules/client-only": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+			"license": "MIT"
+		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"license": "MIT"
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.21.6",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.3.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/esast-util-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+			"integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/esast-util-from-js": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+			"integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"acorn": "^8.0.0",
+				"esast-util-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estree-util-attach-comments": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+			"integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-build-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+			"integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-walker": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-is-identifier-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+			"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-scope": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+			"integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-to-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+			"integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"astring": "^1.8.0",
+				"source-map": "^0.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-visit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+			"integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/github-slugger": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+			"integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+			"license": "ISC"
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/gray-matter": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+			"integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+			"license": "MIT",
+			"dependencies": {
+				"js-yaml": "^3.13.1",
+				"kind-of": "^6.0.2",
+				"section-matter": "^1.0.0",
+				"strip-bom-string": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.0"
+			}
+		},
+		"node_modules/hast-util-from-html": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+			"integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"devlop": "^1.1.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"parse5": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-parse5": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+			"integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"hastscript": "^9.0.0",
+				"property-information": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-location": "^5.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-heading-rank": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+			"integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-is-element": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+			"integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-parse-selector": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+			"integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-estree": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+			"integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-attach-comments": "^3.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-jsx-runtime": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+			"integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-string": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+			"integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hastscript": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+			"integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^4.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
+		},
+		"node_modules/is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/lucide-react": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+			"integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/markdown-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+			"integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdown-table": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+			"integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-gfm-autolink-literal": "^2.0.0",
+				"mdast-util-gfm-footnote": "^2.0.0",
+				"mdast-util-gfm-strikethrough": "^2.0.0",
+				"mdast-util-gfm-table": "^2.0.0",
+				"mdast-util-gfm-task-list-item": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-autolink-literal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"micromark-util-character": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-strikethrough": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"markdown-table": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-task-list-item": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+			"integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-expression": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+			"integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-jsx": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+			"integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"parse-entities": "^4.0.0",
+				"stringify-entities": "^4.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdxjs-esm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+			"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-gfm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-extension-gfm-autolink-literal": "^2.0.0",
+				"micromark-extension-gfm-footnote": "^2.0.0",
+				"micromark-extension-gfm-strikethrough": "^2.0.0",
+				"micromark-extension-gfm-table": "^2.0.0",
+				"micromark-extension-gfm-tagfilter": "^2.0.0",
+				"micromark-extension-gfm-task-list-item": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-strikethrough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-tagfilter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-task-list-item": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-expression": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+			"integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-mdx-jsx": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+			"integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-md": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+			"integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+			"integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.0.0",
+				"acorn-jsx": "^5.0.0",
+				"micromark-extension-mdx-expression": "^3.0.0",
+				"micromark-extension-mdx-jsx": "^3.0.0",
+				"micromark-extension-mdx-md": "^2.0.0",
+				"micromark-extension-mdxjs-esm": "^3.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs-esm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+			"integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-mdx-expression": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+			"integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-events-to-acorn": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+			"integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.13",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+			"integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/next": {
+			"version": "16.2.9",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+			"integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+			"license": "MIT",
+			"dependencies": {
+				"@next/env": "16.2.9",
+				"@swc/helpers": "0.5.15",
+				"baseline-browser-mapping": "^2.9.19",
+				"caniuse-lite": "^1.0.30001579",
+				"postcss": "8.4.31",
+				"styled-jsx": "5.1.6"
+			},
+			"bin": {
+				"next": "dist/bin/next"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"optionalDependencies": {
+				"@next/swc-darwin-arm64": "16.2.9",
+				"@next/swc-darwin-x64": "16.2.9",
+				"@next/swc-linux-arm64-gnu": "16.2.9",
+				"@next/swc-linux-arm64-musl": "16.2.9",
+				"@next/swc-linux-x64-gnu": "16.2.9",
+				"@next/swc-linux-x64-musl": "16.2.9",
+				"@next/swc-win32-arm64-msvc": "16.2.9",
+				"@next/swc-win32-x64-msvc": "16.2.9",
+				"sharp": "^0.34.5"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.1.0",
+				"@playwright/test": "^1.51.1",
+				"babel-plugin-react-compiler": "*",
+				"react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+				"react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+				"sass": "^1.3.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@playwright/test": {
+					"optional": true
+				},
+				"babel-plugin-react-compiler": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/next-mdx-remote": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",
+			"integrity": "sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==",
+			"license": "MPL-2.0",
+			"dependencies": {
+				"@babel/code-frame": "^7.23.5",
+				"@mdx-js/mdx": "^3.0.1",
+				"@mdx-js/react": "^3.0.1",
+				"unist-util-remove": "^3.1.0",
+				"vfile": "^6.0.1",
+				"vfile-matter": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=7"
+			},
+			"peerDependencies": {
+				"react": ">=16"
+			}
+		},
+		"node_modules/next-themes": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+			"integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+			}
+		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"oniguruma-parser": "^0.12.2",
+				"regex": "^6.1.0",
+				"regex-recursion": "^6.0.2"
+			}
+		},
+		"node_modules/parse-entities": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/parse-entities/node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-numeric-range": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+			"integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+			"license": "ISC"
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"license": "ISC"
+		},
+		"node_modules/postcss": {
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/property-information": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+			"integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/react": {
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+			"integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+			"integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+			"license": "MIT",
+			"dependencies": {
+				"scheduler": "^0.27.0"
+			},
+			"peerDependencies": {
+				"react": "^19.2.7"
+			}
+		},
+		"node_modules/recma-build-jsx": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+			"integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-build-jsx": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-jsx": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+			"integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn-jsx": "^5.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"recma-parse": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/recma-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+			"integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"esast-util-from-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-stringify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+			"integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/rehype-autolink-headings": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+			"integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-heading-rank": "^3.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-parse": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+			"integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-from-html": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-pretty-code": {
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.3.tgz",
+			"integrity": "sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.4",
+				"hast-util-to-string": "^3.0.0",
+				"parse-numeric-range": "^1.3.0",
+				"rehype-parse": "^9.0.0",
+				"unified": "^11.0.5",
+				"unist-util-visit": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"shiki": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+			}
+		},
+		"node_modules/rehype-recma": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+			"integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"hast-util-to-estree": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-slug": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+			"integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"github-slugger": "^2.0.0",
+				"hast-util-heading-rank": "^3.0.0",
+				"hast-util-to-string": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-gfm": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-gfm": "^3.0.0",
+				"micromark-extension-gfm": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+			"integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-mdx": "^3.0.0",
+				"micromark-extension-mdxjs": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-rehype": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+			"integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT"
+		},
+		"node_modules/section-matter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+			"integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+			"license": "MIT",
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"kind-of": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/sharp": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/colour": "^1.0.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.34.5",
+				"@img/sharp-darwin-x64": "0.34.5",
+				"@img/sharp-libvips-darwin-arm64": "1.2.4",
+				"@img/sharp-libvips-darwin-x64": "1.2.4",
+				"@img/sharp-libvips-linux-arm": "1.2.4",
+				"@img/sharp-libvips-linux-arm64": "1.2.4",
+				"@img/sharp-libvips-linux-ppc64": "1.2.4",
+				"@img/sharp-libvips-linux-riscv64": "1.2.4",
+				"@img/sharp-libvips-linux-s390x": "1.2.4",
+				"@img/sharp-libvips-linux-x64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+				"@img/sharp-linux-arm": "0.34.5",
+				"@img/sharp-linux-arm64": "0.34.5",
+				"@img/sharp-linux-ppc64": "0.34.5",
+				"@img/sharp-linux-riscv64": "0.34.5",
+				"@img/sharp-linux-s390x": "0.34.5",
+				"@img/sharp-linux-x64": "0.34.5",
+				"@img/sharp-linuxmusl-arm64": "0.34.5",
+				"@img/sharp-linuxmusl-x64": "0.34.5",
+				"@img/sharp-wasm32": "0.34.5",
+				"@img/sharp-win32-arm64": "0.34.5",
+				"@img/sharp-win32-ia32": "0.34.5",
+				"@img/sharp-win32-x64": "0.34.5"
+			}
+		},
+		"node_modules/shiki": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+			"integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "4.2.0",
+				"@shikijs/engine-javascript": "4.2.0",
+				"@shikijs/engine-oniguruma": "4.2.0",
+				"@shikijs/langs": "4.2.0",
+				"@shikijs/themes": "4.2.0",
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/strip-bom-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+			"integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/style-to-js": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"style-to-object": "1.0.14"
+			}
+		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
+			}
+		},
+		"node_modules/styled-jsx": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+			"integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+			"license": "MIT",
+			"dependencies": {
+				"client-only": "0.0.1"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tailwind-merge": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+			"integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/dcastil"
+			}
+		},
+		"node_modules/tailwindcss": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+			"integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tapable": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/tw-animate-css": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+			"integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Wombosvideo"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+			"integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-remove": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.1.tgz",
+			"integrity": "sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0",
+				"unist-util-visit-parents": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-remove/node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"license": "MIT"
+		},
+		"node_modules/unist-util-remove/node_modules/unist-util-is": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+			"integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-remove/node_modules/unist-util-visit-parents": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+			"integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-location": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+			"integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-matter": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
+			"integrity": "sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==",
+			"license": "MIT",
+			"dependencies": {
+				"vfile": "^6.0.0",
+				"yaml": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/web-namespaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+			"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		}
+	}
 }

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -17,7 +17,7 @@
 				"gray-matter": "^4.0.3",
 				"lucide-react": "1.21.0",
 				"next": "16.2.9",
-				"next-mdx-remote": "^5.0.0",
+				"next-mdx-remote": "^6.0.0",
 				"next-themes": "^0.4.6",
 				"react": "19.2.7",
 				"react-dom": "19.2.7",
@@ -3613,15 +3613,16 @@
 			}
 		},
 		"node_modules/next-mdx-remote": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",
-			"integrity": "sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-6.0.0.tgz",
+			"integrity": "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
 				"@mdx-js/mdx": "^3.0.1",
 				"@mdx-js/react": "^3.0.1",
-				"unist-util-remove": "^3.1.0",
+				"unist-util-remove": "^4.0.0",
+				"unist-util-visit": "^5.1.0",
 				"vfile": "^6.0.1",
 				"vfile-matter": "^5.0.0"
 			},
@@ -4370,47 +4371,14 @@
 			}
 		},
 		"node_modules/unist-util-remove": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.1.tgz",
-			"integrity": "sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+			"integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^5.0.0",
-				"unist-util-visit-parents": "^5.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove/node_modules/@types/unist": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-			"license": "MIT"
-		},
-		"node_modules/unist-util-remove/node_modules/unist-util-is": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-			"integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove/node_modules/unist-util-visit-parents": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-			"integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^5.0.0"
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,7 @@
 		"gray-matter": "^4.0.3",
 		"lucide-react": "1.21.0",
 		"next": "16.2.9",
-		"next-mdx-remote": "^5.0.0",
+		"next-mdx-remote": "^6.0.0",
 		"next-themes": "^0.4.6",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",

--- a/site/package.json
+++ b/site/package.json
@@ -9,8 +9,10 @@
 	},
 	"dependencies": {
 		"@radix-ui/react-slot": "^1.3.0",
+		"@types/d3-force": "^3.0.10",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"d3-force": "^3.0.0",
 		"github-slugger": "^2.0.0",
 		"gray-matter": "^4.0.3",
 		"lucide-react": "1.21.0",

--- a/site/scripts/gen-nextjs-depgraph.py
+++ b/site/scripts/gen-nextjs-depgraph.py
@@ -1,0 +1,135 @@
+"""Generate a module-level dependency graph for the Next.js framework core.
+
+Parses packages/next/src with the graph-sitter Rust backend and emits a JSON
+graph (modules as nodes, aggregated import edges) for the docs visualization.
+
+Run from the repo root:
+    uv run python site/scripts/gen-nextjs-depgraph.py
+"""
+import json
+import os
+import time
+from collections import defaultdict
+from pathlib import Path
+
+REPO = os.environ.get("NEXTJS_REPO", "/Users/jayhack/.codex/worktrees/0554/nextjs-sample")
+SUBDIR = "packages/next/src/"
+PREFIX = "packages/next/src/"
+OUT = Path(__file__).resolve().parents[1] / "lib" / "data" / "nextjs-depgraph.json"
+
+from graph_sitter.codebase.config import ProjectConfig
+from graph_sitter.configs.models.codebase import CodebaseConfig, GraphBackend, RustFallbackMode
+from graph_sitter.core.codebase import Codebase
+
+
+def module_of(rel: str) -> str:
+    parts = rel.split("/")
+    if len(parts) <= 1:
+        return "(root)"
+    if len(parts) == 2:
+        return parts[0]
+    return f"{parts[0]}/{parts[1]}"
+
+
+def group_of(rel: str) -> str:
+    return rel.split("/")[0] if "/" in rel else "(root)"
+
+
+def main() -> None:
+    project = ProjectConfig.from_path(REPO).model_copy(update={"subdirectories": [SUBDIR]})
+    t0 = time.perf_counter()
+    cb = Codebase(
+        projects=[project],
+        config=CodebaseConfig(graph_backend=GraphBackend("rust"), rust_fallback=RustFallbackMode("error")),
+    )
+    elapsed = time.perf_counter() - t0
+
+    files = {f.id: f for f in cb.rust_files}
+
+    def rel_of(fid: int):
+        p = files[fid].path if fid in files else None
+        if not p or not p.startswith(PREFIX):
+            return None
+        return p[len(PREFIX):]
+
+    # Aggregate file metrics into modules
+    mod_files = defaultdict(int)
+    mod_loc = defaultdict(int)
+    mod_symbols = defaultdict(int)
+    mod_group = {}
+    file_module = {}
+    for fid, f in files.items():
+        rel = rel_of(fid)
+        if rel is None:
+            continue
+        m = module_of(rel)
+        file_module[fid] = m
+        mod_files[m] += 1
+        mod_loc[m] += f.line_count or 0
+        mod_group[m] = group_of(rel)
+
+    for s in cb.rust_symbols:
+        m = file_module.get(s.file_id)
+        if m is not None:
+            mod_symbols[m] += 1
+
+    # Aggregate module->module import edges from file-level import resolutions
+    edge_w = defaultdict(int)
+    for r in cb.rust_import_resolutions:
+        sm = file_module.get(r.source_file_id)
+        tm = file_module.get(r.target_file_id)
+        if sm is None or tm is None or sm == tm:
+            continue
+        edge_w[(sm, tm)] += 1
+
+    inbound = defaultdict(int)
+    outbound = defaultdict(int)
+    for (sm, tm), w in edge_w.items():
+        inbound[tm] += w
+        outbound[sm] += w
+
+    nodes = []
+    for m in sorted(mod_files):
+        nodes.append(
+            {
+                "id": m,
+                "group": mod_group.get(m, "(root)"),
+                "files": mod_files[m],
+                "loc": mod_loc[m],
+                "symbols": mod_symbols[m],
+                "inbound": inbound.get(m, 0),
+                "outbound": outbound.get(m, 0),
+            }
+        )
+
+    edges = [
+        {"source": sm, "target": tm, "weight": w}
+        for (sm, tm), w in sorted(edge_w.items(), key=lambda kv: -kv[1])
+    ]
+
+    groups = sorted({n["group"] for n in nodes})
+
+    payload = {
+        "meta": {
+            "source": "vercel/next.js · packages/next/src",
+            "parser": "graph-sitter (rust backend)",
+            "parse_seconds": round(elapsed, 2),
+            "files": sum(mod_files.values()),
+            "modules": len(nodes),
+            "edges": len(edges),
+            "symbols": len(list(cb.rust_symbols)),
+        },
+        "groups": groups,
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"parsed in {elapsed:.2f}s")
+    print(f"modules={len(nodes)} edges={len(edges)} groups={groups}")
+    print(f"wrote {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/scripts/gen-nextjs-depgraph.py
+++ b/site/scripts/gen-nextjs-depgraph.py
@@ -6,6 +6,7 @@ graph (modules as nodes, aggregated import edges) for the docs visualization.
 Run from the repo root:
     uv run python site/scripts/gen-nextjs-depgraph.py
 """
+
 import json
 import os
 import time
@@ -50,7 +51,7 @@ def main() -> None:
         p = files[fid].path if fid in files else None
         if not p or not p.startswith(PREFIX):
             return None
-        return p[len(PREFIX):]
+        return p[len(PREFIX) :]
 
     # Aggregate file metrics into modules
     mod_files = defaultdict(int)
@@ -102,10 +103,7 @@ def main() -> None:
             }
         )
 
-    edges = [
-        {"source": sm, "target": tm, "weight": w}
-        for (sm, tm), w in sorted(edge_w.items(), key=lambda kv: -kv[1])
-    ]
+    edges = [{"source": sm, "target": tm, "weight": w} for (sm, tm), w in sorted(edge_w.items(), key=lambda kv: -kv[1])]
 
     groups = sorted({n["group"] for n in nodes})
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/site :/docs"
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"framework": "nextjs",
+	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/site :/docs"
 }

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/site :/docs"
+}


### PR DESCRIPTION
## Summary

Adds a single new page — **`/explore`** — on top of `develop`. It renders the
Next.js framework core (`packages/next/src`) as a force-directed module
dependency graph, parsed with the **graph-sitter Rust backend** (~4.9s, 1,680
files / 16k symbols).

This is the focused, net-new slice of the earlier docs branch — the docs-site
UI itself already lives on `develop`, so this PR only adds what's missing.

## What's included
- `site/app/explore/page.tsx` — the showcase page (graph + top import hubs + the `uvx graph-sitter parse` recipe).
- `site/components/visualizations/dependency-graph.tsx` — `d3-force` layout + hand-rolled HTML5 canvas renderer (Aura-themed, hover/drag/zoom, dark & light); no heavy charting deps.
- `site/lib/data/nextjs-depgraph.json` — generated graph data (91 modules, 710 edges).
- `site/scripts/gen-nextjs-depgraph.py` — reproducible generator (re-run to refresh the data).
- `site/app/page.tsx` — adds an "Explore" link to the homepage nav.
- `d3-force` added to `site/package.json`.

## Test plan
- [x] `npm --prefix site run build` (Node 22) — clean, 305 static pages incl. `/explore`.
- [ ] Review `/explore` in dark and light; confirm graph renders and hover/drag/zoom work.

Made with [Cursor](https://cursor.com)