### PR TITLE
docs: use the Codegen mark as the graph-sitter logo

### DIFF
--- a/site/components/logo.tsx
+++ b/site/components/logo.tsx
@@ -2,30 +2,16 @@ import { cn } from "@/lib/utils";
 
 export function Logo({ className }: { className?: string }) {
 	return (
-		<span
-			className={cn(
-				"inline-flex size-8 items-center justify-center rounded-lg bg-primary/12 text-primary ring-1 ring-inset ring-primary/25",
-				className,
-			)}
+		<svg
+			viewBox="0 0 80.87 80.87"
+			className={cn("size-7 text-foreground", className)}
+			fill="currentColor"
 			aria-hidden="true"
 		>
-			<svg
-				aria-hidden="true"
-				viewBox="0 0 24 24"
-				className="size-[1.05rem]"
-				fill="none"
-				stroke="currentColor"
-				strokeWidth={1.6}
-			>
-				<path
-					d="M7.4 8.4 16 6.2 M7.7 9.9 11.3 15.2 M12.7 15.4 16.6 7.6"
-					strokeLinecap="round"
-				/>
-				<circle cx="6" cy="8" r="2.5" fill="currentColor" stroke="none" />
-				<circle cx="17.6" cy="6" r="2" fill="currentColor" stroke="none" />
-				<circle cx="12" cy="16.4" r="2.3" fill="currentColor" stroke="none" />
-			</svg>
-		</span>
+			<path d="M57.34,27.51c-.79.79-.79,2.07,0,2.86l8.64,8.64c.79.79.79,2.07,0,2.86l-8.64,8.64c-.79.79-.79,2.07,0,2.86l4.29,4.29c.79.79,2.07.79,2.86,0l15.79-15.79c.79-.79.79-2.07,0-2.86l-15.79-15.79c-.79-.79-2.07-.79-2.86,0,0,0-4.29,4.29-4.29,4.29Z" />
+			<path d="M50.19,60.51c-.79-.79-2.07-.79-2.86,0l-5.47,5.47c-.79.79-2.07.79-2.86,0l-24.12-24.12c-.79-.79-.79-2.07,0-2.86l24.12-24.12c.79-.79,2.07-.79,2.86,0l5.47,5.47c.79.79,2.07.79,2.86,0l4.29-4.29c.79-.79.79-2.07,0-2.86L41.86.59c-.79-.79-2.07-.79-2.86,0L.59,39.01c-.79.79-.79,2.07,0,2.86l38.41,38.41c.79.79,2.07.79,2.86,0l12.62-12.62c.79-.79.79-2.07,0-2.86,0,0-4.29-4.29-4.29-4.29Z" />
+			<path d="M50.54,40.44c0,5.58-4.53,10.11-10.11,10.11s-10.11-4.53-10.11-10.11,4.53-10.11,10.11-10.11,10.11,4.53,10.11,10.11Z" />
+		</svg>
 	);
 }
 
@@ -38,7 +24,7 @@ export function Wordmark({ className }: { className?: string }) {
 			)}
 		>
 			<Logo />
-			<span>graph-sitter</span>
+			<span>Graph-sitter</span>
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary

- Replaces the placeholder logo glyph in `components/logo.tsx` with the **Codegen brand mark** (sourced from `codegen/docs/logo/{light,dark}.svg`).
- The mark is rendered inline with `fill="currentColor"` tied to `text-foreground`, so it's **black on light backgrounds and white on dark** — respecting light/dark mode without shipping two asset files.
- Capitalizes the **"Graph-sitter"** wordmark used in the navbar (home, docs, and explore headers all use the shared `Wordmark`).

## Test plan
- [x] `npm run build` in `site/` passes.
- [ ] Toggle light/dark and confirm the logo flips black/white and stays crisp.
- [ ] Confirm the navbar reads "Graph-sitter".

Made with [Cursor](https://cursor.com)