### PR TITLE
docs: shrink navbar logo and add white-on-black favicon

### DIFF
--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -7,7 +7,7 @@
         stroke-width: 0px;
       }
       .background {
-        fill: #2700E5;
+        fill: #0a0a0f;
       }
     </style>
   </defs>

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
 	description:
 		"Write Python programs that understand and safely edit whole codebases.",
 	metadataBase: new URL("https://graph-sitter.com"),
+	icons: {
+		icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
+	},
 	openGraph: {
 		title: "Graph-sitter",
 		description:

--- a/site/components/logo.tsx
+++ b/site/components/logo.tsx
@@ -4,7 +4,7 @@ export function Logo({ className }: { className?: string }) {
 	return (
 		<svg
 			viewBox="0 0 80.87 80.87"
-			className={cn("size-7 text-foreground", className)}
+			className={cn("size-5 text-foreground", className)}
 			fill="currentColor"
 			aria-hidden="true"
 		>


### PR DESCRIPTION
## Summary

Follow-ups to the logo work (#162, now merged):

- **Smaller logo**: the Codegen mark in the navbar wordmark goes from `size-7` → `size-5` so it sits better next to the "Graph-sitter" text.
- **Favicon**: switched the favicon background from blue (`#2700E5`) to black (`#0a0a0f`) — white mark on black — and wired it into the site metadata (`icons.icon`) so it actually renders in the browser tab. The favicon source is `docs/favicon.svg`, which the build syncs to `public/favicon.svg`.

## Test plan
- [x] `npm run build` in `site/` passes.
- [x] Built HTML emits `<link rel="icon" href="/favicon.svg" type="image/svg+xml">`.
- [ ] Confirm the tab favicon shows the white mark on black and the navbar logo looks balanced.

Made with [Cursor](https://cursor.com)