### PR TITLE
docs: fix og:image URL (metadataBase -> graph-sitter.dev)

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
 	title: "Graph-sitter",
 	description:
 		"Write Python programs that understand and safely edit whole codebases.",
-	metadataBase: new URL("https://graph-sitter.com"),
+	metadataBase: new URL("https://graph-sitter.dev"),
 	icons: {
 		icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
 	},
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 		title: "Graph-sitter",
 		description:
 			"Graph files, symbols, imports, calls, and usages so codebase automation can make targeted edits.",
-		url: "https://graph-sitter.com",
+		url: "https://graph-sitter.dev",
 		siteName: "Graph-sitter",
 		type: "website",
 	},


### PR DESCRIPTION
## Summary

The OG image (#163) is merged and deployed — `https://graph-sitter.dev/opengraph-image` renders fine. The reason it wasn't "popping up" in social previews is that `metadataBase` was set to `https://graph-sitter.com`, which is **not a live domain** (the project serves `graph-sitter.dev` / `graph-sitter.vercel.app`). So Next emitted `og:image`/`twitter:image` as absolute URLs at `https://graph-sitter.com/opengraph-image`, which scrapers can't fetch.

This points `metadataBase` and the OpenGraph `url` at the production domain `graph-sitter.dev`.

Before: `og:image content="https://graph-sitter.com/opengraph-image?…"`
After: `og:image content="https://graph-sitter.dev/opengraph-image?…"`

## Test plan
- [x] `npm run build` in `site/` passes; built home HTML now emits `og:image`/`twitter:image` at `https://graph-sitter.dev/opengraph-image`.
- [ ] After deploy, re-scrape with a social/OG debugger (the previews are cached, so they need a refresh).

Made with [Cursor](https://cursor.com)